### PR TITLE
chore: add additional error messages to be ignored in Sentry

### DIFF
--- a/app/Exceptions/Sentry.php
+++ b/app/Exceptions/Sentry.php
@@ -27,6 +27,6 @@ final class Sentry
     private static function shouldBeIgnored(Throwable $exception) : bool
     {
         return ($exception instanceof ViewException || $exception instanceof LaravelViewException)
-            && Str::contains($exception->getMessage(), ['filemtime(): stat failed for', 'unclosed']);
+            && Str::contains($exception->getMessage(), ['filemtime(): stat failed for', 'Unclosed']);
     }
 }

--- a/app/Exceptions/Sentry.php
+++ b/app/Exceptions/Sentry.php
@@ -26,7 +26,14 @@ final class Sentry
 
     private static function shouldBeIgnored(Throwable $exception) : bool
     {
+        $ignorables = [
+            'filemtime(): stat failed for',
+            'Unclosed',
+            'Failed to open stream: No such file or directory',
+            'File does not exist at path'
+        ];
+
         return ($exception instanceof ViewException || $exception instanceof LaravelViewException)
-            && Str::contains($exception->getMessage(), ['filemtime(): stat failed for', 'Unclosed']);
+            && Str::contains($exception->getMessage(), $ignorables);
     }
 }

--- a/app/Exceptions/Sentry.php
+++ b/app/Exceptions/Sentry.php
@@ -30,7 +30,7 @@ final class Sentry
             'filemtime(): stat failed for',
             'Unclosed',
             'Failed to open stream: No such file or directory',
-            'File does not exist at path'
+            'File does not exist at path',
         ];
 
         return ($exception instanceof ViewException || $exception instanceof LaravelViewException)

--- a/tests/Unit/SentryTest.php
+++ b/tests/Unit/SentryTest.php
@@ -32,7 +32,7 @@ it('does not report laravel view exceptions that contain specific messages', fun
     $event = Event::createEvent();
 
     $result = Sentry::before($event, EventHint::fromArray([
-        'exception' => new ViewException('unclosed'),
+        'exception' => new ViewException('Unclosed'),
     ]));
 
     expect($result)->toBeNull();

--- a/tests/Unit/SentryTest.php
+++ b/tests/Unit/SentryTest.php
@@ -54,7 +54,7 @@ it('does not report spatie view exceptions that contain specific messages', func
     $event = Event::createEvent();
 
     $result = Sentry::before($event, EventHint::fromArray([
-        'exception' => new FacadeViewException('unclosed'),
+        'exception' => new FacadeViewException('Unclosed'),
     ]));
 
     expect($result)->toBeNull();
@@ -76,7 +76,7 @@ it('reports all other exceptions even if they contain specific messages', functi
     $event = Event::createEvent();
 
     $result = Sentry::before($event, EventHint::fromArray([
-        'exception' => new RuntimeException('unclosed'),
+        'exception' => new RuntimeException('Unclosed'),
     ]));
 
     expect($result)->toBe($event);

--- a/tests/Unit/Services/ExchangeRateTest.php
+++ b/tests/Unit/Services/ExchangeRateTest.php
@@ -25,7 +25,7 @@ it('should convert with the current rate', function () {
         Carbon::parse('-3 hours')->format('Y-m-d H:i:s') => 1,
         Carbon::parse('-2 hours')->format('Y-m-d H:i:s') => 2,
         Carbon::parse('-1 hour')->format('Y-m-d H:i:s')  => 3,
-        Carbon::now()->format('Y-m-d H:i:s')           => 10,
+        Carbon::now()->format('Y-m-d H:i:s')             => 10,
     ]));
 
     expect(ExchangeRate::now())->toBe(10.0);

--- a/tests/Unit/Services/ExchangeRateTest.php
+++ b/tests/Unit/Services/ExchangeRateTest.php
@@ -22,9 +22,9 @@ it('should convert with a historical rate', function () {
 
 it('should convert with the current rate', function () {
     (new CryptoDataCache())->setPrices('USD.day', collect([
-        Carbon::now('-3 hours')->format('Y-m-d H:i:s') => 1,
-        Carbon::now('-2 hours')->format('Y-m-d H:i:s') => 2,
-        Carbon::now('-1 hour')->format('Y-m-d H:i:s')  => 3,
+        Carbon::parse('-3 hours')->format('Y-m-d H:i:s') => 1,
+        Carbon::parse('-2 hours')->format('Y-m-d H:i:s') => 2,
+        Carbon::parse('-1 hour')->format('Y-m-d H:i:s')  => 3,
         Carbon::now()->format('Y-m-d H:i:s')           => 10,
     ]));
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/2npyb17

For some reason, Laravel's `Str::contains` method no longer ignores casing.

<img width="442" alt="Screenshot 2022-07-22 at 09 04 13" src="https://user-images.githubusercontent.com/6536260/180383587-a6f9adc7-5080-4d5e-ab34-0aa565b2e074.png">

Additionally, I have added rest of the exception messages that cause the Sentry exceptions.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my UI changes in light AND dark mode
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
