### PR TITLE
refactor: keep previous historic data on empty response

### DIFF
--- a/app/Console/Commands/CachePrices.php
+++ b/app/Console/Commands/CachePrices.php
@@ -55,8 +55,10 @@ final class CachePrices extends Command
                     $prices = $hourlyPrices;
                 }
 
-                $crypto->setPrices($currency.'.'.$period, $prices);
-                $cache->setHistorical($currency, $period, $this->statsByPeriod($period, $prices));
+                if (! $prices->isEmpty()) {
+                    $crypto->setPrices($currency.'.'.$period, $prices);
+                    $cache->setHistorical($currency, $period, $this->statsByPeriod($period, $prices));
+                }
             });
         });
     }

--- a/app/Jobs/CacheCurrenciesHistory.php
+++ b/app/Jobs/CacheCurrenciesHistory.php
@@ -34,11 +34,14 @@ final class CacheCurrenciesHistory implements ShouldQueue
     public function handle(NetworkStatusBlockCache $cache, MarketDataProvider $marketDataProvider): void
     {
         try {
-            $cache->setHistoricalHourly(
-                $this->source,
-                $this->currency,
-                $marketDataProvider->historicalHourly($this->source, $this->currency)
-            );
+            $data = $marketDataProvider->historicalHourly($this->source, $this->currency);
+            if (!$data->isEmpty()) {
+                $cache->setHistoricalHourly(
+                    $this->source,
+                    $this->currency,
+                    $data,
+                );
+            }
         } catch (ConnectionException $e) {
             $cache->setHistoricalHourly($this->source, $this->currency, null);
 

--- a/app/Jobs/CacheCurrenciesHistory.php
+++ b/app/Jobs/CacheCurrenciesHistory.php
@@ -35,7 +35,7 @@ final class CacheCurrenciesHistory implements ShouldQueue
     {
         try {
             $data = $marketDataProvider->historicalHourly($this->source, $this->currency);
-            if (!$data->isEmpty()) {
+            if (! $data->isEmpty()) {
                 $cache->setHistoricalHourly(
                     $this->source,
                     $this->currency,

--- a/app/Jobs/CacheCurrenciesHistory.php
+++ b/app/Jobs/CacheCurrenciesHistory.php
@@ -43,8 +43,6 @@ final class CacheCurrenciesHistory implements ShouldQueue
                 );
             }
         } catch (ConnectionException $e) {
-            $cache->setHistoricalHourly($this->source, $this->currency, null);
-
             throw $e;
         }
     }

--- a/app/Services/Cache/Concerns/ManagesCache.php
+++ b/app/Services/Cache/Concerns/ManagesCache.php
@@ -31,11 +31,12 @@ trait ManagesCache
 
     /**
      * @param mixed $value
+     * @param Carbon|int $ttl
      *
      * @return mixed
      */
-    private function put(string $key, $value)
+    private function put(string $key, $value, $ttl = null)
     {
-        return $this->getCache()->put(md5($key), $value);
+        return $this->getCache()->put(md5($key), $value, $ttl = null);
     }
 }

--- a/app/Services/Cache/CryptoDataCache.php
+++ b/app/Services/Cache/CryptoDataCache.php
@@ -32,7 +32,9 @@ final class CryptoDataCache implements Contract
 
     public function setPrices(string $currency, Collection $prices): Collection
     {
-        return $this->remember(sprintf('prices/%s', $currency), now()->addMinutes(10), fn () => $prices);
+        $this->put(sprintf('prices/%s', $currency), $prices, now()->addMinutes(10));
+
+        return $prices;
     }
 
     public function getCache(): TaggedCache

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -10,6 +10,7 @@ use Illuminate\Contracts\Console\Kernel;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Http;
 
 abstract class TestCase extends BaseTestCase
 {
@@ -32,6 +33,18 @@ abstract class TestCase extends BaseTestCase
         );
 
         return $app;
+    }
+
+    /**
+     * Setup the test environment.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Http::preventStrayRequests();
     }
 
     /**

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -17,6 +17,18 @@ abstract class TestCase extends BaseTestCase
     use RefreshDatabase;
 
     /**
+     * Setup the test environment.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Http::preventStrayRequests();
+    }
+
+    /**
      * Creates the application.
      *
      * @return \Illuminate\Foundation\Application
@@ -33,18 +45,6 @@ abstract class TestCase extends BaseTestCase
         );
 
         return $app;
-    }
-
-    /**
-     * Setup the test environment.
-     *
-     * @return void
-     */
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        Http::preventStrayRequests();
     }
 
     /**

--- a/tests/Unit/Console/Commands/CacheCurrenciesHistoryTest.php
+++ b/tests/Unit/Console/Commands/CacheCurrenciesHistoryTest.php
@@ -26,6 +26,8 @@ it('should execute the job', function () {
 it('should execute the command with no delay command', function () {
     Bus::fake();
 
+    Config::set('explorer.network', 'development');
+
     Config::set('currencies', [
         'usd' => [
             'currency' => 'USD',

--- a/tests/Unit/Console/Commands/CachePricesTest.php
+++ b/tests/Unit/Console/Commands/CachePricesTest.php
@@ -178,6 +178,9 @@ it('should update prices if cryptocompare does return a response', function () {
     $crypto = app(CryptoDataCache::class);
     $prices = app(PriceChartCache::class);
 
+    $crypto->getCache()->flush();
+    $prices->getCache()->flush();
+
     $now = Carbon::now();
 
     $mockPrices     = [];

--- a/tests/Unit/Console/Commands/CachePricesTest.php
+++ b/tests/Unit/Console/Commands/CachePricesTest.php
@@ -17,6 +17,10 @@ use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Http;
 use function Tests\fakeCryptoCompare;
 
+beforeEach(function () {
+    $this->travelTo(Carbon::parse('2022-08-18 13:00:00'));
+});
+
 it('should execute the command', function (string $network) {
     fakeCryptoCompare();
 

--- a/tests/Unit/Console/Commands/CachePricesTest.php
+++ b/tests/Unit/Console/Commands/CachePricesTest.php
@@ -130,7 +130,7 @@ it('should update prices if coingecko does return a response', function () {
         'datasets' => [],
     ];
     foreach (range(0, 23) as $hour) {
-        $time = Carbon::now()->sub($hour, 'hours');
+        $time         = Carbon::now()->sub($hour, 'hours');
         $mockPrices[] = [
             $time->valueOf(),
             $hour,
@@ -140,8 +140,8 @@ it('should update prices if coingecko does return a response', function () {
             ->setSeconds(0);
 
         $expectedCrypto[$time->format('Y-m-d H:00:00')] = (string) $hour;
-        $expectedPrices['labels'][]   = $time->format('H:00');
-        $expectedPrices['datasets'][] = (float) $hour;
+        $expectedPrices['labels'][]                     = $time->format('H:00');
+        $expectedPrices['datasets'][]                   = (float) $hour;
     }
 
     Http::fake([
@@ -182,7 +182,7 @@ it('should update prices if cryptocompare does return a response', function () {
         'datasets' => [],
     ];
     foreach (range(0, 23) as $hour) {
-        $time = Carbon::now()->sub($hour, 'hours');
+        $time         = Carbon::now()->sub($hour, 'hours');
         $mockPrices[] = [
             'time'  => $time->timestamp,
             'close' => $hour,
@@ -196,8 +196,8 @@ it('should update prices if cryptocompare does return a response', function () {
             'close' => $hour,
         ];
         $expectedCrypto[$time->format('Y-m-d H:00:00')] = (string) $hour;
-        $expectedPrices['labels'][]   = $time->format('H:00');
-        $expectedPrices['datasets'][] = (float) $hour;
+        $expectedPrices['labels'][]                     = $time->format('H:00');
+        $expectedPrices['datasets'][]                   = (float) $hour;
     }
 
     Http::fake([

--- a/tests/Unit/Console/Commands/CachePricesTest.php
+++ b/tests/Unit/Console/Commands/CachePricesTest.php
@@ -8,7 +8,13 @@ use App\Contracts\Network;
 use App\Services\Blockchain\Network as Blockchain;
 use App\Services\Cache\CryptoDataCache;
 use App\Services\Cache\PriceChartCache;
+use App\Services\MarketDataProviders\CoinGecko;
+use App\Services\MarketDataProviders\CryptoCompare;
+use Carbon\Carbon;
+use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Http;
 use function Tests\fakeCryptoCompare;
 
 it('should execute the command', function (string $network) {
@@ -29,3 +35,120 @@ it('should execute the command', function (string $network) {
     expect($prices->getHistorical('USD', 'quarter'))->toBeArray();
     expect($prices->getHistorical('USD', 'year'))->toBeArray();
 })->with(['explorer.networks.development', 'explorer.networks.production']);
+
+it('should update prices if coingecko does return a response', function () {
+    Config::set('currencies', [
+        'usd' => [
+            'currency' => 'USD',
+            'locale'   => 'en_US',
+        ],
+    ]);
+
+    $crypto = app(CryptoDataCache::class);
+    $prices = app(PriceChartCache::class);
+
+    $crypto->getCache()->flush();
+    $prices->getCache()->flush();
+
+    $now = Carbon::now();
+
+    $mockPrices     = [];
+    $expectedPrices = [
+        'labels'   => [],
+        'datasets' => [],
+    ];
+    foreach (range(0, 23) as $hour) {
+        $time = Carbon::now()->sub($hour, 'hours');
+        $mockPrices[] = [
+            $time->valueOf(),
+            $hour,
+        ];
+
+        $time->setMinutes(0)
+            ->setSeconds(0);
+
+        $expectedCrypto[$time->format('Y-m-d H:00:00')] = (string) $hour;
+        $expectedPrices['labels'][]   = $time->format('H:00');
+        $expectedPrices['datasets'][] = (float) $hour;
+    }
+
+    Http::fake([
+        'https://api.coingecko.com/api/v3/coins/ark/market_chart*' => Http::response([
+            'prices' => $mockPrices,
+        ], 200),
+    ]);
+
+    $crypto->setPrices('USD.day', collect([1, 2, 3]));
+    $prices->setHistorical('USD', 'day', collect([
+        '12:00' => 1,
+        '13:00' => 2,
+        '14:00' => 3,
+    ]));
+
+    (new CachePrices())->handle($crypto, $prices, new CoinGecko());
+
+    expect($crypto->getPrices('USD.day'))->toEqual(collect($expectedCrypto));
+    expect($prices->getHistorical('USD', 'day'))->toEqual($expectedPrices);
+});
+
+it('should update prices if cryptocompare does return a response', function () {
+    Config::set('currencies', [
+        'usd' => [
+            'currency' => 'USD',
+            'locale'   => 'en_US',
+        ],
+    ]);
+
+    $crypto = app(CryptoDataCache::class);
+    $prices = app(PriceChartCache::class);
+
+    $now = Carbon::now();
+
+    $mockPrices     = [];
+    $expectedPrices = [
+        'labels'   => [],
+        'datasets' => [],
+    ];
+    foreach (range(0, 23) as $hour) {
+        $time = Carbon::now()->sub($hour, 'hours');
+        $mockPrices[] = [
+            'time'  => $time->timestamp,
+            'close' => $hour,
+        ];
+
+        $time->setMinutes(0)
+            ->setSeconds(0);
+
+        $mockCrypto[] = [
+            'time'  => $time->timestamp,
+            'close' => $hour,
+        ];
+        $expectedCrypto[$time->format('Y-m-d H:00:00')] = (string) $hour;
+        $expectedPrices['labels'][]   = $time->format('H:00');
+        $expectedPrices['datasets'][] = (float) $hour;
+    }
+
+    Http::fake([
+        'https://min-api.cryptocompare.com/data/histoday*' => Http::response([
+            'Data' => $mockPrices,
+        ], 200),
+    ]);
+
+    Http::fake([
+        'https://min-api.cryptocompare.com/data/histohour*' => Http::response([
+            'Data' => $mockCrypto,
+        ], 200),
+    ]);
+
+    $crypto->setPrices('USD.day', collect([1, 2, 3]));
+    $prices->setHistorical('USD', 'day', collect([
+        '12:00' => 1,
+        '13:00' => 2,
+        '14:00' => 3,
+    ]));
+
+    (new CachePrices())->handle($crypto, $prices, new CryptoCompare());
+
+    expect($crypto->getPrices('USD.day'))->toEqual(collect($expectedCrypto));
+    expect($prices->getHistorical('USD', 'day'))->toEqual($expectedPrices);
+});

--- a/tests/Unit/Console/Commands/CachePricesTest.php
+++ b/tests/Unit/Console/Commands/CachePricesTest.php
@@ -22,6 +22,8 @@ beforeEach(function () {
 });
 
 it('should execute the command', function (string $network) {
+    Config::set('explorer.networks.development.canBeExchanged', true);
+
     fakeCryptoCompare();
 
     $this->app->singleton(Network::class, fn () => new Blockchain(config($network)));
@@ -41,6 +43,8 @@ it('should execute the command', function (string $network) {
 })->with(['explorer.networks.development', 'explorer.networks.production']);
 
 it('should not update prices if coingecko returns an empty response', function () {
+    Config::set('explorer.networks.development.canBeExchanged', true);
+
     $crypto = app(CryptoDataCache::class);
     $prices = app(PriceChartCache::class);
 
@@ -76,6 +80,8 @@ it('should not update prices if coingecko returns an empty response', function (
 });
 
 it('should not update prices if coingecko throws an exception', function () {
+    Config::set('explorer.networks.development.canBeExchanged', true);
+
     $crypto = app(CryptoDataCache::class);
     $prices = app(PriceChartCache::class);
 
@@ -119,6 +125,8 @@ it('should update prices if coingecko does return a response', function () {
             'locale'   => 'en_US',
         ],
     ]);
+
+    Config::set('explorer.network', 'production');
 
     $crypto = app(CryptoDataCache::class);
     $prices = app(PriceChartCache::class);
@@ -174,6 +182,8 @@ it('should update prices if cryptocompare does return a response', function () {
             'locale'   => 'en_US',
         ],
     ]);
+
+    Config::set('explorer.network', 'production');
 
     $crypto = app(CryptoDataCache::class);
     $prices = app(PriceChartCache::class);

--- a/tests/Unit/Jobs/CacheCurrenciesHistoryTest.php
+++ b/tests/Unit/Jobs/CacheCurrenciesHistoryTest.php
@@ -11,6 +11,7 @@ use App\Services\MarketDataProviders\CoinGecko;
 use App\Services\MarketDataProviders\CryptoCompare;
 use Carbon\Carbon;
 use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Http;
 use function Tests\fakeCryptoCompare;
 

--- a/tests/Unit/Jobs/CacheCurrenciesHistoryTest.php
+++ b/tests/Unit/Jobs/CacheCurrenciesHistoryTest.php
@@ -83,7 +83,7 @@ it('should not update prices if coingecko throws an exception', function () {
     expect($cache->getHistoricalHourly('ARK', 'USD'))->toEqual(collect([1, 2, 3]));
 });
 
-it('should update prices if coingecko does not return an empty response', function () {
+it('should update prices if coingecko does return a response', function () {
     $cache = app(NetworkStatusBlockCache::class);
 
     $now = Carbon::now();
@@ -130,7 +130,7 @@ it('should not update prices if cryptocompare throws an exception', function () 
     }
 });
 
-it('should update prices if cryptocompare does not return an empty response', function () {
+it('should update prices if cryptocompare does return a response', function () {
     $cache = app(NetworkStatusBlockCache::class);
 
     $now = Carbon::now();

--- a/tests/Unit/Jobs/CacheCurrenciesHistoryTest.php
+++ b/tests/Unit/Jobs/CacheCurrenciesHistoryTest.php
@@ -15,6 +15,8 @@ use Illuminate\Support\Facades\Http;
 use function Tests\fakeCryptoCompare;
 
 it('should cache the history', function () {
+    Config::set('explorer.networks.development.canBeExchanged', true);
+
     fakeCryptoCompare();
 
     $this->app->singleton(NetworkContract::class, fn () => new Blockchain(config('explorer.networks.production')));
@@ -54,6 +56,8 @@ it('should cache the history', function () {
 });
 
 it('should not update prices if coingecko returns an empty response', function () {
+    Config::set('explorer.networks.development.canBeExchanged', true);
+
     $cache = app(NetworkStatusBlockCache::class);
 
     Http::fake([
@@ -68,6 +72,8 @@ it('should not update prices if coingecko returns an empty response', function (
 });
 
 it('should not update prices if coingecko throws an exception', function () {
+    Config::set('explorer.networks.development.canBeExchanged', true);
+
     $cache = app(NetworkStatusBlockCache::class);
 
     Http::fake([
@@ -84,6 +90,8 @@ it('should not update prices if coingecko throws an exception', function () {
 });
 
 it('should update prices if coingecko does return a response', function () {
+    Config::set('explorer.networks.development.canBeExchanged', true);
+
     $cache = app(NetworkStatusBlockCache::class);
 
     $now = Carbon::now();
@@ -113,6 +121,8 @@ it('should update prices if coingecko does return a response', function () {
 });
 
 it('should not update prices if cryptocompare throws an exception', function () {
+    Config::set('explorer.networks.development.canBeExchanged', true);
+
     $cache = app(NetworkStatusBlockCache::class);
 
     Http::fake([
@@ -131,6 +141,8 @@ it('should not update prices if cryptocompare throws an exception', function () 
 });
 
 it('should update prices if cryptocompare does return a response', function () {
+    Config::set('explorer.networks.development.canBeExchanged', true);
+
     $cache = app(NetworkStatusBlockCache::class);
 
     $now = Carbon::now();

--- a/tests/Unit/Services/MarketDataProviders/CoinGeckoTest.php
+++ b/tests/Unit/Services/MarketDataProviders/CoinGeckoTest.php
@@ -19,8 +19,6 @@ it('should fetch the price data for the given collection', function () {
 });
 
 it('should return an empty value if failed response for price data', function () {
-    Http::preventStrayRequests();
-
     expect((new CoinGecko())->priceAndPriceChange('ARK', collect(['USD'])))->toEqual(collect());
 });
 
@@ -49,8 +47,6 @@ it('should return an empty value if empty response for historical', function () 
 });
 
 it('should return an empty value if failed response for historical', function () {
-    Http::preventStrayRequests();
-
     expect((new CoinGecko())->historical('ARK', 'USD'))->toEqual(collect());
 });
 
@@ -71,8 +67,6 @@ it('should return an empty value if empty response for historical hourly', funct
 });
 
 it('should return an empty value if failed response for historical hourly', function () {
-    Http::preventStrayRequests();
-
     expect((new CoinGecko())->historicalHourly('ARK', 'USD'))->toEqual(collect());
 });
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Changes the currency jobs to keep the data from a prior run in case an empty response is received

What's left:

- [x] add a test for CacheCurrenciesHistory to show it updates data
- [x] add a test for CacheCurrenciesHistory to show it keeps old data in case of an empty response
- [x] add a test for CachePrices to show it updates data
- [x] add a test for CachePrices to show it keeps old data in case of an empty response

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my UI changes in light AND dark mode
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
