### PR TITLE
fix: remove loading state when navbar price has loaded

### DIFF
--- a/app/Http/Livewire/PriceTicker.php
+++ b/app/Http/Livewire/PriceTicker.php
@@ -37,6 +37,8 @@ final class PriceTicker extends Component
         $this->price       = $this->getPriceFormatted();
         $this->from        = Network::currency();
         $this->to          = Settings::currency();
+
+        $this->dispatchBrowserEvent('has-loaded-price-data');
     }
 
     public function render(): View

--- a/resources/views/livewire/price-ticker.blade.php
+++ b/resources/views/livewire/price-ticker.blade.php
@@ -4,6 +4,7 @@
     :class="{ 'opacity-50': busy }"
     x-data="{ to: '{{ $to }}', busy: false }"
     x-init="livewire.on('currencyChanged', () => busy = true);"
+    @has-loaded-price-data="busy = false"
 >
     {{ $from }}/{{ $to }}:
     @if($isAvailable)


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/2vzhqga

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my UI changes in light AND dark mode
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
