### PR TITLE
fix: use correct supply calculation on wallet page

### DIFF
--- a/app/Http/Livewire/Migration/Stats.php
+++ b/app/Http/Livewire/Migration/Stats.php
@@ -23,7 +23,7 @@ class Stats extends Component
     {
         $migratedBalance    = $this->migratedBalance();
         $totalSupply        = $this->totalSupply();
-        $migratedPercentage = $migratedBalance->toInt() / $totalSupply->toInt() * 100;
+        $migratedPercentage = $this->migratedPercentage($migratedBalance, $totalSupply);
         $remainingSupply    = $totalSupply->minus($migratedBalance->valueOf());
 
         return view('livewire.migration.stats', [
@@ -32,6 +32,11 @@ class Stats extends Component
             'percentage'      => NumberFormatter::percentage($migratedPercentage),
             'walletsMigrated' => $this->walletsMigrated(),
         ]);
+    }
+
+    protected function migratedPercentage(BigNumber $migrated, BigNumber $supply): float
+    {
+        return $migrated->toInt() / $supply->toInt() * 100;
     }
 
     protected function migratedBalance(): BigNumber

--- a/app/Http/Livewire/Migration/WalletHighlight.php
+++ b/app/Http/Livewire/Migration/WalletHighlight.php
@@ -11,14 +11,15 @@ final class WalletHighlight extends Stats
 {
     public function render(): View
     {
-        $migratedBalance = $this->migratedBalance();
-        $totalSupply     = $this->totalSupply();
-        $remainingSupply = $totalSupply->minus($migratedBalance->valueOf());
+        $migratedBalance    = $this->migratedBalance();
+        $totalSupply        = $this->totalSupply();
+        $migratedPercentage = $this->migratedPercentage($migratedBalance, $totalSupply);
+        $remainingSupply    = $totalSupply->minus($migratedBalance->valueOf());
 
         return view('livewire.migration.wallet-highlight', [
             'amountMigrated'  => $migratedBalance->toFloat(),
             'remainingSupply' => $remainingSupply->toFloat(),
-            'percentage'      => NumberFormatter::percentage($migratedBalance->toInt() / $totalSupply->toInt()),
+            'percentage'      => NumberFormatter::percentage($migratedPercentage),
             'walletsMigrated' => $this->walletsMigrated(),
         ]);
     }

--- a/tests/Feature/Http/Livewire/Migration/WalletHighlightTest.php
+++ b/tests/Feature/Http/Livewire/Migration/WalletHighlightTest.php
@@ -29,6 +29,6 @@ it('should render the component correctly', function () {
     Livewire::test(WalletHighlight::class)
         ->assertViewHas('amountMigrated', '98.7654321')
         ->assertViewHas('remainingSupply', '813.5802468')
-        ->assertViewHas('percentage', '0.12%')
+        ->assertViewHas('percentage', '10.75%')
         ->assertSee(trans('pages.migration.stats.migration_wallet'));
 });


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Refactors the component so both (migration page and wallet overview page) use the same logic to calculate the supply

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my UI changes in light AND dark mode
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
