### PR TITLE
fix: handle zero network supply

### DIFF
--- a/app/Aggregates/VotePercentageAggregate.php
+++ b/app/Aggregates/VotePercentageAggregate.php
@@ -13,12 +13,17 @@ final class VotePercentageAggregate implements Aggregate
 {
     public function aggregate(): string
     {
+        $supply = CacheNetworkSupply::execute();
+        if ($supply <= 0) {
+            return '0';
+        }
+
         return (string) Percentage::calculate(
             (float) Wallet::query()
                 ->where('balance', '>', 0)
                 ->whereNotNull('attributes->vote')
                 ->sum('balance'),
-            CacheNetworkSupply::execute()
+            $supply
         );
     }
 }

--- a/tests/Unit/Aggregates/VotePercentageAggregateTest.php
+++ b/tests/Unit/Aggregates/VotePercentageAggregateTest.php
@@ -24,7 +24,8 @@ it('should aggregate and format', function () {
     $aggregate = (new VotePercentageAggregate())->aggregate();
 
     expect($aggregate)->toBeString();
-    expect($aggregate)->toBe('73.377809972047');
+    expect($aggregate)->toBe('73.37780997204732');
+    expect($aggregate)->toBe(number_format(10000000000000000 / 13628098200000000 * 100, 12));
 });
 
 it('should return zero if no vote balance', function () {

--- a/tests/Unit/Aggregates/VotePercentageAggregateTest.php
+++ b/tests/Unit/Aggregates/VotePercentageAggregateTest.php
@@ -3,13 +3,10 @@
 declare(strict_types=1);
 
 use App\Aggregates\VotePercentageAggregate;
-use App\Models\Block;
-use App\Models\Transaction;
 use App\Models\Wallet;
 use App\Services\Cache\NetworkCache;
 
 beforeEach(function () {
-
 });
 
 it('should aggregate and format', function () {

--- a/tests/Unit/Aggregates/VotePercentageAggregateTest.php
+++ b/tests/Unit/Aggregates/VotePercentageAggregateTest.php
@@ -24,8 +24,8 @@ it('should aggregate and format', function () {
     $aggregate = (new VotePercentageAggregate())->aggregate();
 
     expect($aggregate)->toBeString();
-    expect($aggregate)->toBe('73.37780997204732');
-    expect($aggregate)->toBe(number_format(10000000000000000 / 13628098200000000 * 100, 12));
+    expect(number_format((float) $aggregate, 12))->toBe('73.377809972047');
+    expect(number_format((float) $aggregate, 12))->toBe(number_format(10000000000000000 / 13628098200000000 * 100, 12));
 });
 
 it('should return zero if no vote balance', function () {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/2rycq50

I couldn't determine why the error was happening. From writing tests, it seems that the division by zero occurs when there is no network supply - possibly an infrastructure issue with connecting to the database or caching services? It may also be resolved as I see no recent occurrences of this happening

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my UI changes in light AND dark mode
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
