### PR TITLE
fix: show newest migration transaction first on migration page

### DIFF
--- a/app/Http/Livewire/Migration/Transactions.php
+++ b/app/Http/Livewire/Migration/Transactions.php
@@ -20,7 +20,7 @@ final class Transactions extends Component
     public function render(): View
     {
         return view('livewire.migration.transactions', [
-            'transactions' => ViewModelFactory::paginate(Transaction::migrated()->paginate(10)),
+            'transactions' => ViewModelFactory::paginate(Transaction::migrated()->orderBy('timestamp', 'desc')->paginate(10)),
         ]);
     }
 }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Depending on the machine, the order could be wrong

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my UI changes in light AND dark mode
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
