### PR TITLE
fix: add explicit primary key column to forging stats

### DIFF
--- a/app/Models/ForgingStats.php
+++ b/app/Models/ForgingStats.php
@@ -24,6 +24,13 @@ final class ForgingStats extends Model
     public $keyType = 'string';
 
     /**
+     * The column name of the primary key
+     *
+     * @var string
+     */
+    public $primaryKey = 'timestamp';
+
+    /**
      * Indicates if the IDs are auto-incrementing.
      *
      * @var bool

--- a/app/Models/ForgingStats.php
+++ b/app/Models/ForgingStats.php
@@ -24,7 +24,7 @@ final class ForgingStats extends Model
     public $keyType = 'string';
 
     /**
-     * The column name of the primary key
+     * The column name of the primary key.
      *
      * @var string
      */


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/8677ccyxy

Adds a primary key column to the ForgingStats model to avoid it getting confused when using `updateOrCreate` that defaults to an `id` column otherwise

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my UI changes in light AND dark mode
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
