### PR TITLE
fix: navbar dropdown widths

### DIFF
--- a/resources/views/components/navbar/navbar.blade.php
+++ b/resources/views/components/navbar/navbar.blade.php
@@ -49,7 +49,7 @@
                                             x-transition.origin.top
                                             x-cloak
                                         >
-                                            <div class="flex flex-col pt-2 pb-2 w-60">
+                                            <div class="flex flex-col pt-2 pb-2">
                                                 @foreach ($navItem['children'] as $menuItem)
                                                     <x-navbar.list-item
                                                         :route="$menuItem['route'] ?? null"


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Makes them use the necessary width instead of a default value

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my UI changes in light AND dark mode
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
