### PR TITLE
fix: flaky wallet voter table test

### DIFF
--- a/tests/Feature/Http/Livewire/WalletVoterTableTest.php
+++ b/tests/Feature/Http/Livewire/WalletVoterTableTest.php
@@ -8,6 +8,7 @@ use App\Models\Wallet;
 use App\Services\Cache\NetworkCache;
 use App\Services\NumberFormatter;
 use App\ViewModels\ViewModelFactory;
+use ARKEcosystem\Foundation\NumberFormatter\NumberFormatter as ARKEcosystemNumberFormatter;
 use Livewire\Livewire;
 use function Tests\fakeCryptoCompare;
 
@@ -30,7 +31,7 @@ it('should list all blocks for the given public key', function () {
 
     foreach (ViewModelFactory::collection($voters) as $voter) {
         $component->assertSee($voter->address());
-        $component->assertSee($voter->balance());
+        $component->assertSee(ARKEcosystemNumberFormatter::new()->formatWithCurrencyCustom($voter->balance(), Network::currency(), 0));
         $component->assertSee(NumberFormatter::currency($voter->balance(), Network::currency()));
         $component->assertSee(NumberFormatter::percentage($voter->votePercentage()));
     }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

To emulate the issue (before applying the fix) add `'balance' => 1000 * 1e8,` in the model factory from the test

The test it fixed by applying the [same formatter](https://github.com/ArkEcosystem/laravel-foundation/blob/0add05766ae8f4671c6057f47c6f25d8d2588212/src/UserInterface/Components/Currency.php#L12) used on the component with the issue 

Closes https://app.clickup.com/t/863gue6g7

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my UI changes in light AND dark mode
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
