### PR TITLE
fix: hidden voters & blocks tables

### DIFF
--- a/resources/views/app/blocks-by-wallet.blade.php
+++ b/resources/views/app/blocks-by-wallet.blade.php
@@ -9,7 +9,7 @@
         <x-page-headers.wallet.blocks :wallet="$wallet" />
 
         <x-ark-container class="border-t-2 dark:border-black border-theme-secondary-200">
-            <div class="w-full" x-cloak>
+            <div class="w-full">
                 <livewire:wallet-block-table :public-key="$wallet->publicKey()" :username="$wallet->username()" />
             </div>
         </x-ark-container>

--- a/resources/views/app/voters-by-wallet.blade.php
+++ b/resources/views/app/voters-by-wallet.blade.php
@@ -9,7 +9,7 @@
         <x-page-headers.wallet.voters :wallet="$wallet" />
 
         <x-ark-container class="border-t-2 dark:border-black border-theme-secondary-200">
-            <div class="w-full" x-cloak>
+            <div class="w-full">
                 <livewire:wallet-voter-table :public-key="$wallet->publicKey()" :username="$wallet->username()" />
             </div>
         </x-ark-container>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

The Voters and Blocks tables for a wallet was hidden. A separate change seemed to have broken this as `x-cloak` wasn't being removed (usually gets removed by a parent alpine object)

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my UI changes in light AND dark mode
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
