### PR TITLE
refactor: exchanges use user currency

### DIFF
--- a/app/Http/Livewire/ExchangeTable.php
+++ b/app/Http/Livewire/ExchangeTable.php
@@ -26,7 +26,10 @@ final class ExchangeTable extends Component
     /**
      * @var mixed
      */
-    protected $listeners = ['filterChanged' => 'setFilter'];
+    protected $listeners = [
+        'filterChanged' => 'setFilter',
+        'currencyChanged' => '$refresh',
+    ];
 
     public function render(): View
     {

--- a/app/Services/ExchangeRate.php
+++ b/app/Services/ExchangeRate.php
@@ -21,7 +21,7 @@ final class ExchangeRate
         return NumberFormatter::currency($amount * $exchangeRate, Settings::currency(), $showSmallAmounts);
     }
 
-    public static function convertFiatToCurrency(float $amount, string $from, string $to, $decimals = 4): ?string
+    public static function convertFiatToCurrency(float $amount, string $from, string $to, int $decimals = 4): ?string
     {
         // Determine the exchange rate based on Network token currency value
         $cache = new NetworkStatusBlockCache();

--- a/app/Services/ExchangeRate.php
+++ b/app/Services/ExchangeRate.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace App\Services;
 
+use App\Facades\Network;
 use App\Facades\Settings;
 use App\Services\Cache\CryptoDataCache;
+use App\Services\Cache\NetworkStatusBlockCache;
 use Carbon\Carbon;
 use Illuminate\Support\Arr;
 
@@ -17,6 +19,27 @@ final class ExchangeRate
         $exchangeRate = Arr::get($prices, Carbon::parse(static::timestamp($timestamp))->format('Y-m-d'), 0);
 
         return NumberFormatter::currency($amount * $exchangeRate, Settings::currency(), $showSmallAmounts);
+    }
+
+    public static function convertFiatToCurrency(float $amount, string $from, string $to, $decimals = 4): ?string
+    {
+        // Determine the exchange rate based on Network token currency value
+        $cache = new NetworkStatusBlockCache();
+
+        $fromValue = $cache->getPrice(Network::currency(), $from);
+        $toValue = $cache->getPrice(Network::currency(), $to);
+
+        if ($fromValue === null || $toValue === null) {
+            return null;
+        }
+
+        $exchangeRate = $toValue / $fromValue;
+
+        if (! NumberFormatter::isFiat($to)) {
+            $decimals = 8;
+        }
+
+        return NumberFormatter::currencyWithDecimals($amount * $exchangeRate, Settings::currency(), $decimals);
     }
 
     public static function now(): float

--- a/app/Services/NumberFormatter.php
+++ b/app/Services/NumberFormatter.php
@@ -64,14 +64,19 @@ final class NumberFormatter
     /**
      * @param string|int|float $value
      */
-    public static function usdWithDecimals($value, ?int $decimals = 4): string
+    public static function currencyWithDecimals($value, string $currency, ?int $decimals = 4): string
     {
-        return BetterNumberFormatter::new()
+        $formatter = BetterNumberFormatter::new()
             ->withLocale('en-US')
             ->withFractionDigits($decimals ?? 4)
-            ->withMinFractionDigits(2)
+            ->withMinFractionDigits(2);
+
+        if (self::isFiat($currency)) {
             // Workaround to fix 5 rounding down (e.g. 1.00005 > 1 instead of 1.0001)
-            ->formatCurrency(floatval(number_format((float) $value, $decimals ?? 4, '.', '')), 'USD');
+            return $formatter->formatCurrency(floatval(number_format((float) $value, $decimals ?? 4, '.', '')), $currency);
+        }
+
+        return $formatter->formatWithCurrencyCustom($value, $currency, $decimals ?? 8);
     }
 
     /**

--- a/resources/lang/en/tables.php
+++ b/resources/lang/en/tables.php
@@ -15,4 +15,9 @@ return [
         'contract'   => 'Contract',
         'multiple'   => 'Multiple',
     ],
+
+    'exchanges' => [
+        'price'  => 'Price (:currency)',
+        'volume' => 'Volume (:currency)',
+    ],
 ];

--- a/resources/views/components/tables/desktop/exchanges.blade.php
+++ b/resources/views/components/tables/desktop/exchanges.blade.php
@@ -17,23 +17,21 @@
             />
 
             <x-tables.headers.desktop.number
-                name="general.exchange.price"
+                name="tables.exchanges.price"
+                :name-properties="['currency' => Settings::currency()]"
                 initial-sort="desc"
                 sorting-id="header-price"
-            >
-                <span>({{ config('currencies.usd.currency') }})</span>
-            </x-tables.headers.desktop.number>
+            />
 
             <x-tables.headers.desktop.number
-                name="general.exchange.volume"
+                name="tables.exchanges.volume"
+                :name-properties="['currency' => Settings::currency()]"
                 class="text-right"
                 breakpoint="md-lg"
                 responsive
                 initial-sort="desc"
                 sorting-id="header-volume"
-            >
-                <span>({{ config('currencies.usd.currency') }})</span>
-            </x-tables.headers.desktop.number>
+            />
         </tr>
     </thead>
 
@@ -67,7 +65,7 @@
                 >
                     @if ($exchange->price)
                         <span class="text-theme-secondary-900 dark:text-theme-secondary-200">
-                            {{ ExplorerNumberFormatter::usdWithDecimals($exchange->price) }}
+                            {{ ExchangeRate::convertFiatToCurrency($exchange->price, 'USD', Settings::currency()) }}
                         </span>
                     @else
                         <span class="text-theme-secondary-500 dark:text-theme-secondary-700">
@@ -83,7 +81,7 @@
                     responsive
                 >
                     @if ($exchange->volume)
-                        {{ ExplorerNumberFormatter::usdWithDecimals($exchange->volume, 2) }}
+                        {{ ExchangeRate::convertFiatToCurrency($exchange->volume, 'USD', Settings::currency(), 2) }}
                     @else
                         <span class="text-theme-secondary-500 dark:text-theme-secondary-700">
                             @lang('general.na')

--- a/resources/views/components/tables/mobile/exchanges.blade.php
+++ b/resources/views/components/tables/mobile/exchanges.blade.php
@@ -33,7 +33,7 @@
 
                     @if ($exchange->price)
                         <span class="text-theme-secondary-900 dark:text-theme-secondary-200">
-                            {{ ExplorerNumberFormatter::usdWithDecimals($exchange->price) }}
+                            {{ ExchangeRate::convertFiatToCurrency($exchange->price, 'USD', Settings::currency()) }}
                         </span>
                     @else
                         <span class="text-theme-secondary-500 dark:text-theme-secondary-700">
@@ -49,7 +49,7 @@
 
                     @if ($exchange->volume)
                         <span class="text-theme-secondary-900 dark:text-theme-secondary-200">
-                            {{ ExplorerNumberFormatter::usdWithDecimals($exchange->volume, 2) }}
+                            {{ ExchangeRate::convertFiatToCurrency($exchange->volume, 'USD', Settings::currency(), 2) }}
                         </span>
                     @else
                         <span class="text-theme-secondary-500 dark:text-theme-secondary-700">

--- a/tests/Unit/Services/ExchangeRateTest.php
+++ b/tests/Unit/Services/ExchangeRateTest.php
@@ -2,7 +2,9 @@
 
 declare(strict_types=1);
 
+use App\Facades\Settings;
 use App\Services\Cache\CryptoDataCache;
+use App\Services\Cache\NetworkStatusBlockCache;
 use App\Services\ExchangeRate;
 use App\Services\NumberFormatter;
 use App\Services\Timestamp;
@@ -29,4 +31,23 @@ it('should convert with the current rate', function () {
     ]));
 
     expect(ExchangeRate::now())->toBe(10.0);
+});
+
+it('should convert one currency to another', function () {
+    Settings::shouldReceive('currency')
+        ->andReturn('GBP');
+
+    (new NetworkStatusBlockCache())->setPrice('DARK', 'USD', 1);
+    (new NetworkStatusBlockCache())->setPrice('DARK', 'GBP', 2);
+
+    expect(ExchangeRate::convertFiatToCurrency(4, 'USD', 'GBP'))->toBe('£8.00');
+});
+
+it('should return null if a currency value is missing', function () {
+    Settings::shouldReceive('currency')
+        ->andReturn('GBP');
+
+    (new NetworkStatusBlockCache())->setPrice('DARK', 'USD', 1);
+
+    expect(ExchangeRate::convertFiatToCurrency(4, 'USD', 'GBP'))->toBeNull();
 });

--- a/tests/Unit/Services/ExchangeRateTest.php
+++ b/tests/Unit/Services/ExchangeRateTest.php
@@ -43,6 +43,16 @@ it('should convert one currency to another', function () {
     expect(ExchangeRate::convertFiatToCurrency(4, 'USD', 'GBP'))->toBe('£8.00');
 });
 
+it('should convert one currency to crypto', function () {
+    Settings::shouldReceive('currency')
+        ->andReturn('BTC');
+
+    (new NetworkStatusBlockCache())->setPrice('DARK', 'USD', 1);
+    (new NetworkStatusBlockCache())->setPrice('DARK', 'BTC', 0.00002);
+
+    expect(ExchangeRate::convertFiatToCurrency(4, 'USD', 'BTC'))->toBe('0.00008 BTC');
+});
+
 it('should return null if a currency value is missing', function () {
     Settings::shouldReceive('currency')
         ->andReturn('GBP');

--- a/tests/Unit/Services/NumberFormatterTest.php
+++ b/tests/Unit/Services/NumberFormatterTest.php
@@ -93,18 +93,27 @@ it('should use two decimals for a fiat currency', function () {
 });
 
 it('should use up to decimals and trim zero', function () {
-    expect(NumberFormatter::usdWithDecimals(1))->toBe('$1.00');
-    expect(NumberFormatter::usdWithDecimals(1.1))->toBe('$1.10');
-    expect(NumberFormatter::usdWithDecimals(1.5))->toBe('$1.50');
-    expect(NumberFormatter::usdWithDecimals(1.05))->toBe('$1.05');
-    expect(NumberFormatter::usdWithDecimals(1.005))->toBe('$1.005');
-    expect(NumberFormatter::usdWithDecimals(1.0005))->toBe('$1.0005');
-    expect(NumberFormatter::usdWithDecimals(1.00005))->toBe('$1.0001');
-    expect(NumberFormatter::usdWithDecimals(1.00004))->toBe('$1.00');
-    expect(NumberFormatter::usdWithDecimals(1.00006))->toBe('$1.0001');
-    expect(NumberFormatter::usdWithDecimals(1.00000))->toBe('$1.00');
-    expect(NumberFormatter::usdWithDecimals(1.1200001))->toBe('$1.12');
-    expect(NumberFormatter::usdWithDecimals(1.1200001, 1))->toBe('$1.10');
-    expect(NumberFormatter::usdWithDecimals(29510))->toBe('$29,510.00');
-    expect(NumberFormatter::usdWithDecimals(29510.1))->toBe('$29,510.10');
+    expect(NumberFormatter::currencyWithDecimals(1, 'USD'))->toBe('$1.00');
+    expect(NumberFormatter::currencyWithDecimals(1.1, 'USD'))->toBe('$1.10');
+    expect(NumberFormatter::currencyWithDecimals(1.5, 'USD'))->toBe('$1.50');
+    expect(NumberFormatter::currencyWithDecimals(1.05, 'USD'))->toBe('$1.05');
+    expect(NumberFormatter::currencyWithDecimals(1.005, 'USD'))->toBe('$1.005');
+    expect(NumberFormatter::currencyWithDecimals(1.0005, 'USD'))->toBe('$1.0005');
+    expect(NumberFormatter::currencyWithDecimals(1.00005, 'USD'))->toBe('$1.0001');
+    expect(NumberFormatter::currencyWithDecimals(1.00004, 'USD'))->toBe('$1.00');
+    expect(NumberFormatter::currencyWithDecimals(1.00006, 'USD'))->toBe('$1.0001');
+    expect(NumberFormatter::currencyWithDecimals(1.00000, 'USD'))->toBe('$1.00');
+    expect(NumberFormatter::currencyWithDecimals(1.1200001, 'USD'))->toBe('$1.12');
+    expect(NumberFormatter::currencyWithDecimals(1.1200001, 'USD', 1))->toBe('$1.10');
+    expect(NumberFormatter::currencyWithDecimals(29510, 'USD'))->toBe('$29,510.00');
+    expect(NumberFormatter::currencyWithDecimals(29510.1, 'USD'))->toBe('$29,510.10');
 });
+
+it('should format other currencies', function ($currency, $expectation) {
+    expect(NumberFormatter::currencyWithDecimals(1.0005, $currency))->toBe($expectation);
+})->with([
+    'GBP' => ['GBP', '£1.0005'],
+    'EUR' => ['EUR', '€1.0005'],
+    'ETH' => ['ETH', '1.0005 ETH'],
+    'BTC' => ['BTC', '1.0005 BTC'],
+]);


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/861mvv8xb

To test:

- Set env to production - `ARKSCAN_NETWORK=production` **make sure no other envs are set to look for devnet**
- Run horizon - `php artisan horizon`
- Load in Exchanges - `php artisan exchanges:load`
- Load in Exchange Details - `php artisan exchanges:fetch-details`
- Load in cache data - `php artisan explorer:cache-currencies-data`
- Go to exchanges page - `/exchanges` **should be visible from the navbar at this point**
- Change currency

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my UI changes in light AND dark mode
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
