### PR TITLE
fix: navbar dark text color single item entry

### DIFF
--- a/resources/views/components/navbar/item.blade.php
+++ b/resources/views/components/navbar/item.blade.php
@@ -11,7 +11,7 @@
     @class([
         'inline-flex font-semibold leading-5 group focus:outline-none transition duration-150 ease-in-out h-full px-2 mx-4 relative border-t-2 border-transparent rounded',
         'text-theme-secondary-900 dark:text-theme-secondary-400' => $currentRoute === $route,
-        'text-theme-secondary-700 hover:text-theme-secondary-800 dark:text-theme-secondary-500 dark:hover:text-theme-secondary-400' => $currentRoute !== $route,
+        'text-theme-secondary-700 hover:text-theme-secondary-800 dark:text-theme-secondary-400 dark:hover:text-theme-secondary-400' => $currentRoute !== $route,
     ])
 >
     <span @class([


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

small adjustment so entries without dropdown are in line with entries with dropdown

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my UI changes in light AND dark mode
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
