### PR TITLE
fix: delegate productivity colors in light mode

### DIFF
--- a/resources/views/components/wallet/overview/delegate/productivity.blade.php
+++ b/resources/views/components/wallet/overview/delegate/productivity.blade.php
@@ -17,7 +17,7 @@
             'text-theme-secondary-500 dark:text-theme-secondary-700' => ! $wallet->isActive(),
             'text-theme-danger-700 dark:text-theme-danger-400' => $isLow,
             'text-theme-warning-700' => $isMedium,
-            'text-theme-success-500' => $isHigh,
+            'text-theme-success-700 dark:text-theme-success-500' => $isHigh,
         ])>
             <div>
                 <x-percentage>

--- a/resources/views/components/wallet/overview/delegate/rank.blade.php
+++ b/resources/views/components/wallet/overview/delegate/rank.blade.php
@@ -20,7 +20,7 @@
                 @lang('pages.delegates.standby')
             </span>
         @else
-            <span class="text-theme-success-500">
+            <span class="text-theme-success-700 dark:text-theme-success-500">
                 @lang('pages.delegates.active')
             </span>
         @endif


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/861mz6u5m

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my UI changes in light AND dark mode
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
