### PR TITLE
fix: delegates missed blocks with per page options

### DIFF
--- a/app/Http/Livewire/Delegates/Delegates.php
+++ b/app/Http/Livewire/Delegates/Delegates.php
@@ -93,15 +93,11 @@ final class Delegates extends Component
 
     public function getShowMissedBlocksProperty(): bool
     {
-        if ($this->page > 1) {
-            return false;
-        }
-
         if ($this->filter['active'] === false) {
             return false;
         }
 
-        return true;
+        return ($this->page - 1) * $this->perPage < Network::delegateCount();
     }
 
     public function perPageOptions(): array

--- a/tests/Feature/Http/Livewire/Delegates/DelegatesTest.php
+++ b/tests/Feature/Http/Livewire/Delegates/DelegatesTest.php
@@ -33,14 +33,25 @@ it('should show no results message if no delegates', function () {
         ->assertSee(trans('tables.delegates.no_results.no_results'));
 });
 
-it('should not show missed blocks on page 2', function () {
-    Wallet::factory(102)->activeDelegate()->create();
+it('should not show missed blocks if no active delegates', function ($perPage, $lastPageWithActive) {
+    Wallet::factory(400)->activeDelegate()->create();
 
-    Livewire::test(Delegates::class, ['deferLoading' => false])
-        ->assertSee(trans('tables.delegates.missed_blocks'))
-        ->call('gotoPage', 2)
+    $component = Livewire::test(Delegates::class, ['deferLoading' => false])
+        ->call('setPerPage', $perPage);
+
+    for ($page = 1; $page <= $lastPageWithActive; $page++) {
+        $component->call('gotoPage', $page)
+            ->assertSee(trans('tables.delegates.missed_blocks'));
+    }
+
+    $component->call('gotoPage', $lastPageWithActive + 1)
         ->assertDontSee(trans('tables.delegates.missed_blocks'));
-});
+})->with([
+    10 => [10, 6],
+    25 => [25, 3],
+    51 => [51, 1],
+    100 => [100, 1],
+]);
 
 it('should have slightly different per-page options', function () {
     $instance = Livewire::test(Delegates::class, ['deferLoading' => false])

--- a/tests/Feature/Http/Livewire/Delegates/DelegatesTest.php
+++ b/tests/Feature/Http/Livewire/Delegates/DelegatesTest.php
@@ -47,9 +47,9 @@ it('should not show missed blocks if no active delegates', function ($perPage, $
     $component->call('gotoPage', $lastPageWithActive + 1)
         ->assertDontSee(trans('tables.delegates.missed_blocks'));
 })->with([
-    10 => [10, 6],
-    25 => [25, 3],
-    51 => [51, 1],
+    10  => [10, 6],
+    25  => [25, 3],
+    51  => [51, 1],
     100 => [100, 1],
 ]);
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/862kc1f00

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my UI changes in light AND dark mode
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
