### PR TITLE
fix: make page subtitle lighter to increase readability in dark mode

### DIFF
--- a/resources/views/components/page-headers/generic.blade.php
+++ b/resources/views/components/page-headers/generic.blade.php
@@ -9,7 +9,7 @@
             {{ $title }}
         </h1>
 
-        <span class="text-xs text-theme-secondary-500 leading-3.75 dark:text-theme-dark-500">
+        <span class="text-xs text-theme-secondary-500 leading-3.75 dark:text-theme-secondary-500">
             {{ $subtitle }}
         </span>
     </div>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

was very dark before and hard to read

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my UI changes in light AND dark mode
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
