### PR TITLE
refactor: delegates additional handling

### DIFF
--- a/app/Http/Livewire/Delegates/Delegates.php
+++ b/app/Http/Livewire/Delegates/Delegates.php
@@ -152,28 +152,38 @@ final class Delegates extends TabbedTableComponent
                 if (count($voterCounts) === 0) {
                     $query->selectRaw('0 AS no_of_voters')
                         ->selectRaw('wallets.*');
-                } else {
-                    $query->selectRaw('voting_stats.count AS no_of_voters')
-                        ->selectRaw('wallets.*')
-                        ->join(DB::raw(sprintf(
-                            '(values %s) as voting_stats (public_key, count)',
-                            collect($voterCounts)
-                                ->map(fn ($count, $publicKey) => sprintf('(\'%s\',%d)', $publicKey, $count))
-                                ->join(','),
-                        )), 'wallets.public_key', '=', 'voting_stats.public_key', 'left outer')
-                        ->orderByRaw(sprintf('no_of_voters %s NULLS LAST, ("attributes"->\'delegate\'->>\'rank\')::numeric ASC', $sortDirection->value));
+
+                    return;
                 }
+
+                $query->selectRaw('voting_stats.count AS no_of_voters')
+                    ->selectRaw('wallets.*')
+                    ->join(DB::raw(sprintf(
+                        '(values %s) as voting_stats (public_key, count)',
+                        collect($voterCounts)
+                            ->map(fn ($count, $publicKey) => sprintf('(\'%s\',%d)', $publicKey, $count))
+                            ->join(','),
+                    )), 'wallets.public_key', '=', 'voting_stats.public_key', 'left outer')
+                    ->orderByRaw(sprintf('no_of_voters %s NULLS LAST, ("attributes"->\'delegate\'->>\'rank\')::numeric ASC', $sortDirection->value));
             })
             ->when($this->sortKey === 'missed_blocks', function ($query) use ($sortDirection) {
+                $missedBlocks = ForgingStats::selectRaw('public_key, COUNT(*) as count')
+                    ->groupBy('public_key')
+                    ->whereNot('missed_height', null)
+                    ->get();
+
+                if (count($missedBlocks) === 0) {
+                    $query->selectRaw('0 AS missed_blocks')
+                        ->selectRaw('wallets.*');
+
+                    return;
+                }
+
                 $query->selectRaw('forging_stats.count AS missed_blocks')
                     ->selectRaw('wallets.*')
                     ->join(DB::raw(sprintf(
                         '(values %s) as forging_stats (public_key, count)',
-                        ForgingStats::selectRaw('public_key, COUNT(*) as count')
-                            ->groupBy('public_key')
-                            ->whereNot('missed_height', null)
-                            ->get()
-                            ->map(fn ($forgingStat) => sprintf('(\'%s\',%d)', $forgingStat->public_key, $forgingStat->count))
+                        $missedBlocks->map(fn ($forgingStat) => sprintf('(\'%s\',%d)', $forgingStat->public_key, $forgingStat->count))
                             ->join(','),
                     )), 'wallets.public_key', '=', 'forging_stats.public_key', 'left outer')
                     ->orderByRaw(sprintf('missed_blocks %s NULLS LAST, ("attributes"->\'delegate\'->>\'rank\')::numeric ASC', $sortDirection->value));

--- a/app/ViewModels/ForgingStatsViewModel.php
+++ b/app/ViewModels/ForgingStatsViewModel.php
@@ -24,14 +24,14 @@ final class ForgingStatsViewModel implements ViewModel
         return new WalletViewModel($this->forgingStats->delegate);
     }
 
-    public function address(): string
+    public function address(): ?string
     {
-        return $this->delegate()?->address() ?? 'Genesis';
+        return $this->delegate()?->address();
     }
 
-    public function username(): string
+    public function username(): ?string
     {
-        return $this->delegate()?->username() ?? 'Genesis';
+        return $this->delegate()?->username();
     }
 
     public function timestamp(): string

--- a/resources/views/components/tables/desktop/delegates/missed-blocks.blade.php
+++ b/resources/views/components/tables/desktop/delegates/missed-blocks.blade.php
@@ -60,6 +60,7 @@
 
     <tbody>
         @foreach($blocks as $block)
+            @php ($delegate = $block->delegate())
             <x-ark-tables.row wire:key="{{ Helpers::generateId('block', $block->timestamp()) }}">
                 <x-ark-tables.cell>
                     <x-tables.rows.desktop.encapsulated.block-height
@@ -74,25 +75,29 @@
                 </x-ark-tables.cell>
 
                 <x-ark-tables.cell>
-                    <x-tables.rows.desktop.encapsulated.address
-                        :model="$block"
-                        without-clipboard
-                    />
+                    @if ($delegate)
+                        <x-tables.rows.desktop.encapsulated.address
+                            :model="$block"
+                            without-clipboard
+                        />
+                    @else
+                        <span>-</span>
+                    @endif
                 </x-ark-tables.cell>
 
                 <x-ark-tables.cell class="text-right">
                     <x-tables.rows.desktop.encapsulated.delegates.number-of-voters
-                        :model="$block->delegate()"
+                        :model="$delegate"
                         without-breakdown
                     />
                 </x-ark-tables.cell>
 
                 <x-ark-tables.cell class="text-right">
-                    <x-tables.rows.desktop.encapsulated.delegates.votes :model="$block->delegate()" />
+                    <x-tables.rows.desktop.encapsulated.delegates.votes :model="$delegate" />
                 </x-ark-tables.cell>
 
                 <x-ark-tables.cell class="text-right">
-                    <x-tables.rows.desktop.encapsulated.delegates.votes-percentage :model="$block->delegate()" />
+                    <x-tables.rows.desktop.encapsulated.delegates.votes-percentage :model="$delegate" />
                 </x-ark-tables.cell>
             </x-ark-tables.row>
         @endforeach

--- a/resources/views/components/tables/mobile/delegates/missed-blocks.blade.php
+++ b/resources/views/components/tables/mobile/delegates/missed-blocks.blade.php
@@ -8,9 +8,11 @@
     :no-results-message="$noResultsMessage"
 >
     @foreach ($blocks as $block)
+        @php ($delegate = $block->delegate())
+
         <x-tables.rows.mobile
             wire:key="{{ Helpers::generateId('block-mobile', $block->timestamp()) }}"
-            expandable
+            :expandable="$delegate !== null"
         >
             <x-slot name="header">
                 <div class="flex flex-1 justify-between">
@@ -20,11 +22,13 @@
                         without-link
                     />
 
-                    <x-tables.rows.mobile.encapsulated.delegates.address
-                        :model="$block->delegate()"
-                        class="hidden sm:block sm:flex-1"
-                        without-label
-                    />
+                    @if ($delegate)
+                        <x-tables.rows.mobile.encapsulated.delegates.address
+                            :model="$delegate"
+                            class="hidden sm:block sm:flex-1"
+                            without-label
+                        />
+                    @endif
 
                     <x-tables.rows.mobile.encapsulated.age
                         :model="$block"
@@ -33,23 +37,25 @@
                 </div>
             </x-slot>
 
-            <x-tables.rows.mobile.encapsulated.delegates.address
-                :model="$block->delegate()"
-                class="sm:hidden"
-            />
+            @if ($delegate)
+                <x-tables.rows.mobile.encapsulated.delegates.address
+                    :model="$delegate"
+                    class="sm:hidden"
+                />
 
-            <x-tables.rows.mobile.encapsulated.delegates.number-of-voters
-                :model="$block->delegate()"
-                class="sm:flex-1"
-            />
+                <x-tables.rows.mobile.encapsulated.delegates.number-of-voters
+                    :model="$delegate"
+                    class="sm:flex-1"
+                />
 
-            <div class="sm:flex-1">
-                <x-tables.rows.mobile.encapsulated.delegates.votes :model="$block->delegate()" />
-            </div>
+                <div class="sm:flex-1">
+                    <x-tables.rows.mobile.encapsulated.delegates.votes :model="$delegate" />
+                </div>
 
-            <div class="sm:flex sm:justify-end sm:min-w-[110px]">
-                <x-tables.rows.mobile.encapsulated.delegates.votes-percentage :model="$block->delegate()" />
-            </div>
+                <div class="sm:flex sm:justify-end sm:min-w-[110px]">
+                    <x-tables.rows.mobile.encapsulated.delegates.votes-percentage :model="$delegate" />
+                </div>
+            @endif
         </x-tables.rows.mobile>
     @endforeach
 </x-tables.mobile.includes.encapsulated>

--- a/resources/views/components/tables/rows/desktop/encapsulated/delegates/number-of-voters.blade.php
+++ b/resources/views/components/tables/rows/desktop/encapsulated/delegates/number-of-voters.blade.php
@@ -4,15 +4,19 @@
 ])
 
 <x-tables.rows.desktop.encapsulated.cell class="text-theme-secondary-900 dark:text-theme-secondary-200">
-    <x-number>{{ $model->voterCount() }}</x-number>
+    @if ($model)
+        <x-number>{{ $model->voterCount() }}</x-number>
 
-    @unless($withoutBreakdown)
-        <div class="hidden mt-1 space-x-2 text-xs divide-x sm:flex lg:hidden divide divide-theme-secondary-300 text-theme-secondary-700 dark:text-theme-dark-200 dark:divide-theme-dark-700">
-            <div>{{ number_format($model->votes()) }}</div>
+        @unless($withoutBreakdown)
+            <div class="hidden mt-1 space-x-2 text-xs divide-x sm:flex lg:hidden divide divide-theme-secondary-300 text-theme-secondary-700 dark:text-theme-dark-200 dark:divide-theme-dark-700">
+                <div>{{ number_format($model->votes()) }}</div>
 
-            <div class="pl-2">
-                <x-percentage>{{ $model->votePercentage() }}</x-percentage>
+                <div class="pl-2">
+                    <x-percentage>{{ $model->votePercentage() }}</x-percentage>
+                </div>
             </div>
-        </div>
-    @endunless
+        @endunless
+    @else
+        <span>-</span>
+    @endif
 </x-tables.rows.desktop.encapsulated.cell>

--- a/resources/views/components/tables/rows/desktop/encapsulated/delegates/votes-percentage.blade.php
+++ b/resources/views/components/tables/rows/desktop/encapsulated/delegates/votes-percentage.blade.php
@@ -1,5 +1,9 @@
 @props(['model'])
 
 <x-tables.rows.desktop.encapsulated.cell class="text-theme-secondary-900 dark:text-theme-secondary-200">
-    <x-percentage>{{ $model->votesPercentage() }}</x-percentage>
+    @if ($model)
+        <x-percentage>{{ $model->votesPercentage() }}</x-percentage>
+    @else
+        <span>-</span>
+    @endif
 </x-tables.rows.desktop.encapsulated.cell>

--- a/resources/views/components/tables/rows/desktop/encapsulated/delegates/votes.blade.php
+++ b/resources/views/components/tables/rows/desktop/encapsulated/delegates/votes.blade.php
@@ -1,13 +1,17 @@
 @props(['model'])
 
-@php ($votes = $model->votes())
+@php ($votes = $model?->votes())
 
 <x-tables.rows.desktop.encapsulated.cell class="text-theme-secondary-900 dark:text-theme-secondary-200">
-    @if ($votes > 0 && $votes < 0.01)
-        <span data-tippy-content="{{ ExplorerNumberFormatter::unformattedRawValue($votes) }}">
-            &lt;0.01
-        </span>
+    @if ($model)
+        @if ($votes > 0 && $votes < 0.01)
+            <span data-tippy-content="{{ ExplorerNumberFormatter::unformattedRawValue($votes) }}">
+                &lt;0.01
+            </span>
+        @else
+            {{ number_format($votes, 2) }}
+        @endif
     @else
-        {{ number_format($votes, 2) }}
+        <span>-</span>
     @endif
 </x-tables.rows.desktop.encapsulated.cell>

--- a/tests/Analysis/AnalysisTest.php
+++ b/tests/Analysis/AnalysisTest.php
@@ -29,6 +29,7 @@ final class AnalysisTest extends TestCase
             'Laravel\Scout\Builder',
             'Spatie\Snapshots\assertMatchesSnapshot',
             'Tests\bip39',
+            'Tests\faker',
             'Tests\fakeCryptoCompare',
             'Tests\fakeKnownWallets',
         ];

--- a/tests/Feature/Http/Livewire/Delegates/DelegatesTest.php
+++ b/tests/Feature/Http/Livewire/Delegates/DelegatesTest.php
@@ -11,7 +11,6 @@ use App\Services\Cache\WalletCache;
 use App\Services\Timestamp;
 use Carbon\Carbon;
 use Illuminate\Support\Arr;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Route;
 use Illuminate\View\Compilers\BladeCompiler;
 use Livewire\Livewire;
@@ -875,7 +874,7 @@ it('should force ascending if invalid query string value', function () {
 it('should handle sorting several pages of delegates without cached data', function ($columnSortBy, $modelSortBy) {
     $delegateData = [];
     foreach (range(1, 145) as $rank) {
-        $wallet = faker()->wallet;
+        $wallet         = faker()->wallet;
         $delegateData[] = [
             'id'                => faker()->uuid,
             'balance'           => faker()->numberBetween(1, 1000) * 1e8,
@@ -930,18 +929,18 @@ it('should handle sorting several pages of delegates without cached data', funct
             ]);
     }
 })->with([
-    'rank' => ['rank', 'attributes.delegate.rank'],
-    'name' => ['name', 'attributes.delegate.username'],
-    'no_of_voters' => ['no_of_voters', 'attributes.delegate.rank'],
-    'votes' => ['votes', 'attributes.delegate.voteBalance'],
+    'rank'             => ['rank', 'attributes.delegate.rank'],
+    'name'             => ['name', 'attributes.delegate.username'],
+    'no_of_voters'     => ['no_of_voters', 'attributes.delegate.rank'],
+    'votes'            => ['votes', 'attributes.delegate.voteBalance'],
     'percentage_votes' => ['percentage_votes', 'attributes.delegate.voteBalance'],
-    'missed_blocks' => ['missed_blocks', 'attributes.delegate.rank'],
+    'missed_blocks'    => ['missed_blocks', 'attributes.delegate.rank'],
 ]);
 
 it('should handle sorting several pages of delegates with cached data', function ($columnSortBy, $modelSortBy) {
     $delegateData = [];
     foreach (range(1, 145) as $rank) {
-        $wallet = faker()->wallet;
+        $wallet         = faker()->wallet;
         $delegateData[] = [
             'id'                => faker()->uuid,
             'balance'           => faker()->numberBetween(1, 1000) * 1e8,
@@ -972,8 +971,8 @@ it('should handle sorting several pages of delegates with cached data', function
 
     $delegates = Wallet::all();
 
-    $voterCounts  = [];
-    $missedBlocks = [];
+    $voterCounts        = [];
+    $missedBlocks       = [];
     $missedBlockCounter = 0;
 
     $missedBlocksData = [];
@@ -982,8 +981,8 @@ it('should handle sorting several pages of delegates with cached data', function
         $missedBlockCount = random_int(2, 4);
         foreach (range(1, $missedBlockCount) as $_) {
             $missedBlocksData[] = [
-                'timestamp'  => Timestamp::fromUnix(Carbon::now()->subHours($missedBlockCounter)->unix())->unix(),
-                'public_key' => $delegate->public_key,
+                'timestamp'     => Timestamp::fromUnix(Carbon::now()->subHours($missedBlockCounter)->unix())->unix(),
+                'public_key'    => $delegate->public_key,
                 'forged'        => faker()->boolean(),
                 'missed_height' => faker()->numberBetween(1, 10000),
             ];
@@ -1005,7 +1004,7 @@ it('should handle sorting several pages of delegates with cached data', function
         if ($modelSortBy === 'missed_blocks') {
             $aValue = count($missedBlocks[$a->public_key]);
             $bValue = count($missedBlocks[$b->public_key]);
-        } else if ($modelSortBy === 'no_of_voters') {
+        } elseif ($modelSortBy === 'no_of_voters') {
             $aValue = $voterCounts[$a->public_key];
             $bValue = $voterCounts[$b->public_key];
         } else {
@@ -1035,10 +1034,10 @@ it('should handle sorting several pages of delegates with cached data', function
             ]);
     }
 })->with([
-    'rank' => ['rank', 'attributes.delegate.rank'],
-    'name' => ['name', 'attributes.delegate.username'],
-    'no_of_voters' => ['no_of_voters', 'no_of_voters'],
-    'votes' => ['votes', 'attributes.delegate.voteBalance'],
+    'rank'             => ['rank', 'attributes.delegate.rank'],
+    'name'             => ['name', 'attributes.delegate.username'],
+    'no_of_voters'     => ['no_of_voters', 'no_of_voters'],
+    'votes'            => ['votes', 'attributes.delegate.voteBalance'],
     'percentage_votes' => ['percentage_votes', 'attributes.delegate.voteBalance'],
-    'missed_blocks' => ['missed_blocks', 'missed_blocks'],
+    'missed_blocks'    => ['missed_blocks', 'missed_blocks'],
 ]);

--- a/tests/Feature/Http/Livewire/Delegates/MissedBlocksTest.php
+++ b/tests/Feature/Http/Livewire/Delegates/MissedBlocksTest.php
@@ -722,7 +722,7 @@ it('should force ascending if invalid query string value', function () {
 it('should handle sorting several pages without cached data', function ($columnSortBy, $modelSortBy) {
     $delegateData = [];
     foreach (range(1, 145) as $rank) {
-        $wallet = faker()->wallet;
+        $wallet         = faker()->wallet;
         $delegateData[] = [
             'id'                => faker()->uuid,
             'balance'           => faker()->numberBetween(1, 1000) * 1e8,
@@ -751,7 +751,7 @@ it('should handle sorting several pages without cached data', function ($columnS
 
     Wallet::insert($delegateData);
 
-    $missedBlocks = [];
+    $missedBlocks       = [];
     $missedBlockCounter = 0;
 
     $missedBlocksData = [];
@@ -762,8 +762,8 @@ it('should handle sorting several pages without cached data', function ($columnS
         $missedBlockCount = random_int(2, 4);
         foreach (range(1, $missedBlockCount) as $_) {
             $missedBlocksData[] = [
-                'timestamp'  => Timestamp::fromUnix(Carbon::now()->subHours($missedBlockCounter)->unix())->unix(),
-                'public_key' => $delegate->public_key,
+                'timestamp'     => Timestamp::fromUnix(Carbon::now()->subHours($missedBlockCounter)->unix())->unix(),
+                'public_key'    => $delegate->public_key,
                 'forged'        => faker()->boolean(),
                 'missed_height' => faker()->numberBetween(1, 10000),
             ];
@@ -804,18 +804,18 @@ it('should handle sorting several pages without cached data', function ($columnS
             ]);
     }
 })->with([
-    'height' => ['height', 'missed_height'],
-    'age' => ['age', 'timestamp'],
-    'name' => ['name', 'timestamp'],
-    'no_of_voters' => ['no_of_voters', 'timestamp'],
-    'votes' => ['votes', 'timestamp'],
+    'height'           => ['height', 'missed_height'],
+    'age'              => ['age', 'timestamp'],
+    'name'             => ['name', 'timestamp'],
+    'no_of_voters'     => ['no_of_voters', 'timestamp'],
+    'votes'            => ['votes', 'timestamp'],
     'percentage_votes' => ['percentage_votes', 'timestamp'],
 ]);
 
 it('should handle sorting several pages with cached data', function ($columnSortBy, $modelSortBy) {
     $delegateData = [];
     foreach (range(1, 145) as $rank) {
-        $wallet = faker()->wallet;
+        $wallet         = faker()->wallet;
         $delegateData[] = [
             'id'                => faker()->uuid,
             'balance'           => faker()->numberBetween(1, 1000) * 1e8,
@@ -844,8 +844,8 @@ it('should handle sorting several pages with cached data', function ($columnSort
 
     Wallet::insert($delegateData);
 
-    $voterCounts = [];
-    $missedBlocks = [];
+    $voterCounts        = [];
+    $missedBlocks       = [];
     $missedBlockCounter = 0;
 
     $missedBlocksData = [];
@@ -856,8 +856,8 @@ it('should handle sorting several pages with cached data', function ($columnSort
         $missedBlockCount = random_int(2, 4);
         foreach (range(1, $missedBlockCount) as $_) {
             $missedBlocksData[] = [
-                'timestamp'  => Timestamp::fromUnix(Carbon::now()->subHours($missedBlockCounter)->unix())->unix(),
-                'public_key' => $delegate->public_key,
+                'timestamp'     => Timestamp::fromUnix(Carbon::now()->subHours($missedBlockCounter)->unix())->unix(),
+                'public_key'    => $delegate->public_key,
                 'forged'        => faker()->boolean(),
                 'missed_height' => faker()->numberBetween(1, 10000),
             ];
@@ -879,10 +879,10 @@ it('should handle sorting several pages with cached data', function ($columnSort
         if ($modelSortBy === 'no_of_voters') {
             $aValue = $voterCounts[$a->public_key];
             $bValue = $voterCounts[$b->public_key];
-        } else if ($modelSortBy === 'votes' || $modelSortBy === 'percentage_votes') {
+        } elseif ($modelSortBy === 'votes' || $modelSortBy === 'percentage_votes') {
             $aValue = Arr::get($delegates[$a->public_key], 'attributes.delegate.voteBalance');
             $bValue = Arr::get($delegates[$b->public_key], 'attributes.delegate.voteBalance');
-        } else if ($modelSortBy === 'name') {
+        } elseif ($modelSortBy === 'name') {
             $aValue = Arr::get($delegates[$a->public_key], 'attributes.delegate.username');
             $bValue = Arr::get($delegates[$b->public_key], 'attributes.delegate.username');
         } else {
@@ -912,10 +912,10 @@ it('should handle sorting several pages with cached data', function ($columnSort
             ]);
     }
 })->with([
-    'height' => ['height', 'missed_height'],
-    'age' => ['age', 'timestamp'],
-    'name' => ['name', 'name'],
-    'no_of_voters' => ['no_of_voters', 'no_of_voters'],
-    'votes' => ['votes', 'votes'],
+    'height'           => ['height', 'missed_height'],
+    'age'              => ['age', 'timestamp'],
+    'name'             => ['name', 'name'],
+    'no_of_voters'     => ['no_of_voters', 'no_of_voters'],
+    'votes'            => ['votes', 'votes'],
     'percentage_votes' => ['percentage_votes', 'percentage_votes'],
 ]);

--- a/tests/Feature/Http/Livewire/Delegates/RecentVotesTest.php
+++ b/tests/Feature/Http/Livewire/Delegates/RecentVotesTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 use App\Enums\SortDirection;
 use App\Http\Livewire\Delegates\RecentVotes;
 use App\Models\Block;
-use App\Models\ForgingStats;
 use App\Models\Transaction;
 use App\Models\Wallet;
 use App\Services\Timestamp;
@@ -554,12 +553,12 @@ it('should force default sort direction if invalid query string value', function
 });
 
 it('should handle sorting several pages without cached data', function ($columnSortBy, $modelSortBy) {
-    $delegateData = [];
+    $delegateData    = [];
     $transactionData = [];
-    $block = Block::factory()->create();
+    $block           = Block::factory()->create();
 
     foreach (range(1, 145) as $rank) {
-        $wallet = faker()->wallet;
+        $wallet         = faker()->wallet;
         $delegateData[] = [
             'id'                => faker()->uuid,
             'balance'           => faker()->numberBetween(1, 1000) * 1e8,
@@ -632,8 +631,8 @@ it('should handle sorting several pages without cached data', function ($columnS
             ]);
     }
 })->with([
-    'age' => ['age', 'timestamp'],
+    'age'     => ['age', 'timestamp'],
     'address' => ['address', 'timestamp'],
-    'type' => ['type', 'timestamp'],
-    'name' => ['name', 'timestamp'],
+    'type'    => ['type', 'timestamp'],
+    'name'    => ['name', 'timestamp'],
 ]);

--- a/tests/Feature/Http/Livewire/Delegates/RecentVotesTest.php
+++ b/tests/Feature/Http/Livewire/Delegates/RecentVotesTest.php
@@ -4,13 +4,17 @@ declare(strict_types=1);
 
 use App\Enums\SortDirection;
 use App\Http\Livewire\Delegates\RecentVotes;
+use App\Models\Block;
+use App\Models\ForgingStats;
 use App\Models\Transaction;
 use App\Models\Wallet;
 use App\Services\Timestamp;
 use Carbon\Carbon;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Route;
 use Illuminate\View\Compilers\BladeCompiler;
 use Livewire\Livewire;
+use function Tests\faker;
 
 it('should render', function () {
     Livewire::test(RecentVotes::class)
@@ -548,3 +552,88 @@ it('should force default sort direction if invalid query string value', function
             $data['voteSwapTransaction']->address,
         ]);
 });
+
+it('should handle sorting several pages without cached data', function ($columnSortBy, $modelSortBy) {
+    $delegateData = [];
+    $transactionData = [];
+    $block = Block::factory()->create();
+
+    foreach (range(1, 145) as $rank) {
+        $wallet = faker()->wallet;
+        $delegateData[] = [
+            'id'                => faker()->uuid,
+            'balance'           => faker()->numberBetween(1, 1000) * 1e8,
+            'nonce'             => faker()->numberBetween(1, 1000),
+            'attributes'        => [
+                'delegate'        => [
+                    'username'       => faker()->userName,
+                    'voteBalance'    => faker()->numberBetween(1, 1000) * 1e8,
+                    'producedBlocks' => faker()->numberBetween(1, 1000),
+                    'missedBlocks'   => faker()->numberBetween(1, 1000),
+                ],
+            ],
+            'updated_at'       => faker()->dateTimeBetween('-1 year', 'now'),
+
+            'address'    => $wallet['address'],
+            'public_key' => $wallet['publicKey'],
+            'attributes' => json_encode([
+                'delegate' => [
+                    'rank'        => $rank,
+                    'username'    => 'delegate-'.$rank,
+                    'voteBalance' => random_int(1000, 10000) * 1e8,
+                ],
+            ]),
+        ];
+
+        $transactionData[] = [
+            'id'                => faker()->transactionId,
+            'block_id'          => $block->id,
+            'block_height'      => faker()->numberBetween(1, 10000),
+            'type'              => 3,
+            'type_group'        => 1,
+            'sender_public_key' => $wallet['publicKey'],
+            'recipient_id'      => $wallet['address'],
+            'timestamp'         => Timestamp::fromUnix(Carbon::now()->subHours($rank)->unix())->unix(),
+            'fee'               => faker()->numberBetween(1, 100) * 1e8,
+            'amount'            => faker()->numberBetween(1, 100) * 1e8,
+            'nonce'             => 1,
+            'asset'             => json_encode([]),
+        ];
+    }
+
+    Wallet::insert($delegateData);
+    Transaction::insert($transactionData);
+
+    $transactions = Wallet::all();
+
+    $transactions = $transactions->sort(function ($a, $b) use ($modelSortBy) {
+        $aValue = Arr::get($a, $modelSortBy);
+        $bValue = Arr::get($b, $modelSortBy);
+
+        if (is_numeric($bValue) && is_numeric($aValue)) {
+            return (int) $aValue - (int) $bValue;
+        }
+
+        return strcmp($aValue, $bValue);
+    });
+
+    $component = Livewire::test(RecentVotes::class)
+        ->call('setIsReady')
+        ->call('sortBy', $columnSortBy)
+        ->set('sortDirection', SortDirection::ASC);
+
+    foreach (range(1, 4) as $page) {
+        $pageData = $transactions->chunk(25)->get($page - 1)->pluck('address');
+
+        $component->call('gotoPage', $page)
+            ->assertSeeInOrder([
+                ...$pageData,
+                ...$pageData,
+            ]);
+    }
+})->with([
+    'age' => ['age', 'timestamp'],
+    'address' => ['address', 'timestamp'],
+    'type' => ['type', 'timestamp'],
+    'name' => ['name', 'timestamp'],
+]);

--- a/tests/Helpers.php
+++ b/tests/Helpers.php
@@ -5,11 +5,10 @@ declare(strict_types=1);
 namespace Tests;
 
 use ArkEcosystem\Crypto\Identities\PublicKey;
+use Faker\Generator;
 use FurqanSiddiqui\BIP39\BIP39;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Str;
-use Faker\Factory;
-use Faker\Generator;
 
 function faker(): Generator
 {

--- a/tests/Helpers.php
+++ b/tests/Helpers.php
@@ -8,6 +8,13 @@ use ArkEcosystem\Crypto\Identities\PublicKey;
 use FurqanSiddiqui\BIP39\BIP39;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Str;
+use Faker\Factory;
+use Faker\Generator;
+
+function faker(): Generator
+{
+    return app(Generator::class);
+}
 
 function fakeKnownWallets(): void
 {

--- a/tests/Unit/ViewModels/ForgingStatsViewModelTest.php
+++ b/tests/Unit/ViewModels/ForgingStatsViewModelTest.php
@@ -64,13 +64,12 @@ it('should get the delegate username', function () {
     expect($this->subject->username())->toBe('joe.blogs');
 });
 
-it('should fail to get the delegate username', function () {
+it('should handle no delegate username', function () {
     $wallet = Wallet::factory()->activeDelegate()->create(['attributes' => []]);
 
     $this->subject = new ForgingStatsViewModel(ForgingStats::factory()->create([
         'public_key' => $wallet->public_key,
     ]));
 
-    expect($this->subject->username())->toBeString();
-    expect($this->subject->username())->toBe('Genesis');
+    expect($this->subject->username())->toBeNull();
 });


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/8678ur3qk

@ItsANameToo added some handling for when there are missed blocks for delegates that don't exist (e.g. when we run tests locally and it starts throwing an error). It effectively just hyphen's the data in the table. Sorting doesn't break under these circumstances either. If you'd prefer not to have this as it's only caused by local issues I can revert it

![image](https://github.com/ArdentHQ/arkscan/assets/8069294/f14ad73a-f2ea-4345-b932-5a7c4bac6469)

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my UI changes in light AND dark mode
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
