### PR TITLE
refactor: disable scroll lock on ios safari

### DIFF
--- a/resources/views/components/navbar/mobile.blade.php
+++ b/resources/views/components/navbar/mobile.blade.php
@@ -5,7 +5,27 @@
         x-data="Navbar.dropdown({
             dark: window.getThemeMode() === 'dark',
             open: false,
-            showSettings: false
+            showSettings: false,
+
+            lockBody() {
+                return ! this.isIOSSafari() && window.innerWidth <= this.lockBodyBreakpoint;
+            },
+
+            isIOSSafari() {
+                if (! /(Macintosh)|(Mac OS)|(iPad)|(iPod)|(iPhone)/.test(window.navigator.userAgent)) {
+                    return false;
+                }
+
+                if (! /(Safari)/.test(window.navigator.userAgent)) {
+                    return false;
+                }
+
+                if (! /(AppleWebKit)/.test(window.navigator.userAgent)) {
+                    return false;
+                }
+
+                return ('ontouchstart' in window) || (navigator.MaxTouchPoints > 0) || (navigator.msMaxTouchPoints > 0);
+            },
         })"
         @theme-changed.window="dark = $event.detail.theme === 'dark'"
     >


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/863h6be09

Will need testing on other devices and browsers. This specifically disables the navbar scroll lock for Safari browsers on iOS touchscreen devices

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my UI changes in light AND dark mode
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
