### PR TITLE
refactor: delegate monitor consistent cache ttl

### DIFF
--- a/app/Services/Cache/Concerns/ManagesCache.php
+++ b/app/Services/Cache/Concerns/ManagesCache.php
@@ -42,7 +42,7 @@ trait ManagesCache
         return $this->getCache()->put(md5($key), $value, $ttl = null);
     }
 
-    protected function blockTimeTTL(): int
+    private function blockTimeTTL(): int
     {
         return (int) ceil(Network::blockTime() / 2);
     }

--- a/app/Services/Cache/Concerns/ManagesCache.php
+++ b/app/Services/Cache/Concerns/ManagesCache.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Services\Cache\Concerns;
 
+use App\Facades\Network;
 use Carbon\Carbon;
 use Closure;
 
@@ -39,5 +40,10 @@ trait ManagesCache
     private function put(string $key, $value, $ttl = null)
     {
         return $this->getCache()->put(md5($key), $value, $ttl = null);
+    }
+
+    protected function blockTimeTTL(): int
+    {
+        return (int) ceil(Network::blockTime() / 2);
     }
 }

--- a/app/Services/Cache/MonitorCache.php
+++ b/app/Services/Cache/MonitorCache.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace App\Services\Cache;
 
 use App\Contracts\Cache as Contract;
-use App\Facades\Network;
 use App\Services\Cache\Concerns\ManagesCache;
 use App\ViewModels\WalletViewModel;
 use Closure;
@@ -21,12 +20,12 @@ final class MonitorCache implements Contract
 
     public function setBlockCount(Closure $callback): string
     {
-        return $this->remember('block_count', Network::blockTime(), $callback);
+        return $this->remember('block_count', $this->blockTimeTTL(), $callback);
     }
 
     public function setNextDelegate(Closure $callback): ? WalletViewModel
     {
-        return $this->remember('next_delegate', Network::blockTime(), $callback);
+        return $this->remember('next_delegate', $this->blockTimeTTL(), $callback);
     }
 
     public function getCache(): TaggedCache

--- a/app/Services/Cache/NetworkCache.php
+++ b/app/Services/Cache/NetworkCache.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace App\Services\Cache;
 
 use App\Contracts\Cache as Contract;
-use App\Facades\Network;
 use App\Services\Cache\Concerns\ManagesCache;
 use Closure;
 use Illuminate\Cache\TaggedCache;
@@ -108,10 +107,5 @@ final class NetworkCache implements Contract
     public function getCache(): TaggedCache
     {
         return Cache::tags('network');
-    }
-
-    private function blockTimeTTL(): int
-    {
-        return (int) ceil(Network::blockTime() / 2);
     }
 }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/862khmpj7

I've adjusted the caching so they all use the same (block time / 2). I'm not sure if this resolves the issue if I'm honest. The caches work as follows:

**Height**
Performs `Block::max('height')` so it relies on database

**Current Round**
Also uses `Block::max('height')` to determine how many blocks have been forged

**Next Slot**
Uses different logic based on the calculated slots for the whole round. 

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my UI changes in light AND dark mode
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
