### PR TITLE
fix: delegate monitor mobile skeleton duplicate dropdown icon

### DIFF
--- a/resources/views/components/tables/skeletons/encapsulated/mobile/delegates/monitor.blade.php
+++ b/resources/views/components/tables/skeletons/encapsulated/mobile/delegates/monitor.blade.php
@@ -1,6 +1,11 @@
+@props([
+    'rowCount' => 15,
+])
+
 <x-tables.mobile.includes.encapsulated>
-    <x-skeleton :row-count="$rowCount">
+    @for ($i = 0; $i < $rowCount; $i++)
         <x-tables.rows.mobile
+            wire:key="skeleton-delegate-monitor-{{ $i }}"
             expandable
             expand-disabled
         >
@@ -34,5 +39,5 @@
                 <x-tables.rows.mobile.skeletons.encapsulated.text />
             </div>
         </x-tables.rows.mobile>
-    </x-skeleton>
+    @endfor
 </x-tables.mobile.includes.encapsulated>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/862khr6aw

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my UI changes in light AND dark mode
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
