### PR TITLE
fix: hide resigned delegates by default in table

### DIFF
--- a/app/Http/Livewire/Delegates/Delegates.php
+++ b/app/Http/Livewire/Delegates/Delegates.php
@@ -38,7 +38,7 @@ final class Delegates extends TabbedTableComponent
     public array $filter = [
         'active'   => true,
         'standby'  => true,
-        'resigned' => true,
+        'resigned' => false,
     ];
 
     /** @var mixed */

--- a/tests/Feature/Http/Livewire/Delegates/DelegatesTest.php
+++ b/tests/Feature/Http/Livewire/Delegates/DelegatesTest.php
@@ -96,6 +96,12 @@ it('should toggle "select all" when all filters are selected', function () {
         ->assertSet('filter', [
             'active'   => true,
             'standby'  => true,
+            'resigned' => false,
+        ])
+        ->set('filter.resigned', true)
+        ->assertSet('filter', [
+            'active'   => true,
+            'standby'  => true,
             'resigned' => true,
         ])
         ->assertSet('selectAllFilters', true)

--- a/tests/Feature/Http/Livewire/Delegates/DelegatesTest.php
+++ b/tests/Feature/Http/Livewire/Delegates/DelegatesTest.php
@@ -65,6 +65,12 @@ it('should toggle all filters when "select all" is selected', function () {
         ->assertSet('filter', [
             'active'   => true,
             'standby'  => true,
+            'resigned' => false,
+        ])
+        ->set('filter.resigned', true)
+        ->assertSet('filter', [
+            'active'   => true,
+            'standby'  => true,
             'resigned' => true,
         ])
         ->assertSet('selectAllFilters', true)


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/862khv8xc

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my UI changes in light AND dark mode
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
