### PR TITLE
chore: rename homepage statistics volume

### DIFF
--- a/resources/lang/en/pages.php
+++ b/resources/lang/en/pages.php
@@ -34,7 +34,7 @@ return [
         'statistics' => [
             'title'               => 'Statistics',
             'current_supply'      => 'Current Supply',
-            'volume'              => 'Volume (24h)',
+            'exchange_volume'              => 'Exchange Volume (24h)',
             'market_cap'          => 'Market Cap',
             'block_height'        => 'Block Height',
             'currency_price'      => ':currency Price',

--- a/resources/lang/en/pages.php
+++ b/resources/lang/en/pages.php
@@ -32,13 +32,13 @@ return [
 
     'home'             => [
         'statistics' => [
-            'title'               => 'Statistics',
-            'current_supply'      => 'Current Supply',
+            'title'                        => 'Statistics',
+            'current_supply'               => 'Current Supply',
             'exchange_volume'              => 'Exchange Volume (24h)',
-            'market_cap'          => 'Market Cap',
-            'block_height'        => 'Block Height',
-            'currency_price'      => ':currency Price',
-            'chart_not_supported' => 'Not supported on development networks',
+            'market_cap'                   => 'Market Cap',
+            'block_height'                 => 'Block Height',
+            'currency_price'               => ':currency Price',
+            'chart_not_supported'          => 'Not supported on development networks',
         ],
 
         'footer' => [

--- a/resources/views/livewire/home/statistics.blade.php
+++ b/resources/views/livewire/home/statistics.blade.php
@@ -21,7 +21,7 @@
 
     <div class="flex flex-col flex-1 pt-3 space-y-3 divide-y sm:pt-0 divide-theme-secondary-300 dark:divide-theme-dark-700">
         <x-home.stat
-            :title="trans('pages.home.statistics.volume')"
+            :title="trans('pages.home.statistics.exchange_volume')"
             :disabled="! Network::canBeExchanged() || $volume === null"
         >
             {{ $volume }}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

rename `volume` -> `exchange volume` on homepage

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my UI changes in light AND dark mode
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
