### PR TITLE
fix: unalignment between table loading state and data top account

### DIFF
--- a/resources/views/components/tables/desktop/top-accounts.blade.php
+++ b/resources/views/components/tables/desktop/top-accounts.blade.php
@@ -108,13 +108,13 @@
                     breakpoint="md-lg"
                     responsive
                 >
-                    <span class="font-semibold leading-4.25">
+                    <div class="flex font-semibold">
                         @if($useVoteWeight)
                             <x-tables.rows.desktop.vote-percentage :model="$wallet" />
                         @else
                             <x-tables.rows.desktop.balance-percentage :model="$wallet" />
                         @endif
-                    </span>
+                    </div>
                 </x-ark-tables.cell>
             </x-ark-tables.row>
         @endforeach


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/862kh72c8

the `flex` is needed to make sure the `leading` size gets applied properly, otherwise it changes to `20px` instead of `17px`

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my UI changes in light AND dark mode
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
