### PR TITLE
refactor: don't use negative 1 for productivity

### DIFF
--- a/app/Jobs/CacheProductivityByPublicKey.php
+++ b/app/Jobs/CacheProductivityByPublicKey.php
@@ -39,7 +39,7 @@ final class CacheProductivityByPublicKey implements ShouldQueue
 
         $walletCache->setProductivity(
             $this->publicKey,
-            $total > 0 ? Percentage::calculate($forged, $total) : -1
+            $total > 0 ? Percentage::calculate($forged, $total) : 0
         );
     }
 }

--- a/app/ViewModels/Concerns/Wallet/CanForge.php
+++ b/app/ViewModels/Concerns/Wallet/CanForge.php
@@ -42,7 +42,12 @@ trait CanForge
             return 0;
         }
 
-        return (new WalletCache())->getProductivity($publicKey);
+        $productivity = (new WalletCache())->getProductivity($publicKey);
+        if ($productivity <= 0) {
+            return 0;
+        }
+
+        return $productivity;
     }
 
     public function performance(): array

--- a/tests/Unit/Console/Commands/CacheAnnualStatisticsTest.php
+++ b/tests/Unit/Console/Commands/CacheAnnualStatisticsTest.php
@@ -35,6 +35,8 @@ it('should cache annual data for current year', function () {
 });
 
 it('should cache annual data for all time', function () {
+    $this->travelTo(Carbon::parse('2023-08-12'));
+
     $cache       = new StatisticsCache();
     $currentTime = Carbon::now();
     $currentYear = $currentTime->year;

--- a/tests/Unit/ViewModels/WalletViewModelTest.php
+++ b/tests/Unit/ViewModels/WalletViewModelTest.php
@@ -494,7 +494,7 @@ it('should fail to get the productivity if the wallet is a delegate', function (
     ]));
 
     expect($this->subject->productivity())->toBeFloat();
-    expect($this->subject->productivity())->toBe(-1.0);
+    expect($this->subject->productivity())->toBe(0.0);
 
     (new WalletCache())->setProductivity($this->subject->publicKey(), 10);
 
@@ -515,6 +515,15 @@ it('should fail to get the productivity if the wallet has no public key', functi
     $this->subject = new WalletViewModel(Wallet::factory()->create([
         'public_key' => null,
     ]));
+
+    expect($this->subject->productivity())->toBeFloat();
+    expect($this->subject->productivity())->toBe(0.0);
+});
+
+it('should return 0 for productivity if the cached value is less than 0', function () {
+    $this->subject = new WalletViewModel(Wallet::factory()->create());
+
+    (new WalletCache())->setProductivity($this->subject->publicKey(), -1);
 
     expect($this->subject->productivity())->toBeFloat();
     expect($this->subject->productivity())->toBe(0.0);


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/86dqnrgz7

instead of red -1% for new delegates, it will now show red 0% productivity

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my UI changes in light AND dark mode
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
