### PR TITLE
fix: integer out of range exception

### DIFF
--- a/app/Http/Controllers/BlocksController.php
+++ b/app/Http/Controllers/BlocksController.php
@@ -38,7 +38,7 @@ final class BlocksController
                 ->selectRaw('COUNT(*) as block_count')
                 ->selectRaw('SUM(reward) as total_rewards')
                 ->selectRaw('MAX(total_amount) as largest_amount')
-                ->where('timestamp', '>', ((int) $timestamp) * 1000)
+                ->where('timestamp', '>',  $timestamp * 1000)
                 ->first();
 
             return [

--- a/app/Http/Controllers/BlocksController.php
+++ b/app/Http/Controllers/BlocksController.php
@@ -38,7 +38,7 @@ final class BlocksController
                 ->selectRaw('COUNT(*) as block_count')
                 ->selectRaw('SUM(reward) as total_rewards')
                 ->selectRaw('MAX(total_amount) as largest_amount')
-                ->where('timestamp', '>',  $timestamp * 1000)
+                ->where('timestamp', '>', $timestamp * 1000)
                 ->first();
 
             return [

--- a/app/Http/Controllers/BlocksController.php
+++ b/app/Http/Controllers/BlocksController.php
@@ -38,7 +38,7 @@ final class BlocksController
                 ->selectRaw('COUNT(*) as block_count')
                 ->selectRaw('SUM(reward) as total_rewards')
                 ->selectRaw('MAX(total_amount) as largest_amount')
-                ->where('timestamp', '>', $timestamp * 1000)
+                ->where('timestamp', '>', ((int) $timestamp) * 1000)
                 ->first();
 
             return [

--- a/app/Http/Controllers/BlocksController.php
+++ b/app/Http/Controllers/BlocksController.php
@@ -31,13 +31,14 @@ final class BlocksController
     private function blockData(): array
     {
         return Cache::remember('blocks:stats', self::STATS_TTL, function () {
-            $timestamp = Timestamp::fromUnix(Carbon::now()->subDays(1)->unix())->unix() * 1000;
+            $timestamp = Timestamp::fromUnix(Carbon::now()->subDays(1)->unix())->unix();
+            
             $data      = (array) DB::connection('explorer')
                 ->table('blocks')
                 ->selectRaw('COUNT(*) as block_count')
                 ->selectRaw('SUM(reward) as total_rewards')
                 ->selectRaw('MAX(total_amount) as largest_amount')
-                ->where('timestamp', '>', $timestamp)
+                ->where('timestamp', '>', $timestamp * 1000)
                 ->first();
 
             return [


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

As you [can see here](https://github.com/ArdentHQ/arkscan/blob/mainsail/app/Jobs/BuildForgingStats.php#L43-L59) he timestamp for the `forging_stats` is not stored as `ms` (is not multiplied by 1k) which means the condition that causes the exception is incorrect, we should not use the ms unix timestamp

Updating that condition should solve the out of range exceptions

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my UI changes in light AND dark mode
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
