### PR TITLE
refactor: update delegate aggregates caching

### DIFF
--- a/app/Console/Commands/CacheDelegateAggregates.php
+++ b/app/Console/Commands/CacheDelegateAggregates.php
@@ -28,12 +28,12 @@ final class CacheDelegateAggregates extends Command
     {
         $aggregate = (new DelegateTotalAggregates())->aggregate();
 
-        $cache->setTotalAmounts(fn () => $aggregate->pluck('total_amount', 'generator_public_key')->toArray());
+        $cache->setTotalAmounts($aggregate->pluck('total_amount', 'generator_public_key')->toArray());
 
-        $cache->setTotalFees(fn () => $aggregate->pluck('total_fee', 'generator_public_key')->toArray());
+        $cache->setTotalFees($aggregate->pluck('total_fee', 'generator_public_key')->toArray());
 
-        $cache->setTotalRewards(fn () => $aggregate->pluck('reward', 'generator_public_key')->toArray());
+        $cache->setTotalRewards($aggregate->pluck('reward', 'generator_public_key')->toArray());
 
-        $cache->setTotalBlocks(fn () => $aggregate->pluck('count', 'generator_public_key')->toArray());
+        $cache->setTotalBlocks($aggregate->pluck('count', 'generator_public_key')->toArray());
     }
 }

--- a/app/Services/Cache/DelegateCache.php
+++ b/app/Services/Cache/DelegateCache.php
@@ -19,9 +19,9 @@ final class DelegateCache implements Contract
         return $this->get('total_amounts', []);
     }
 
-    public function setTotalAmounts(Closure $callback): array
+    public function setTotalAmounts(Closure $callback): void
     {
-        return $this->remember('total_amounts', now()->addHour(), $callback);
+        $this->put('total_amounts', $callback());
     }
 
     public function getTotalBlocks(): array
@@ -29,9 +29,9 @@ final class DelegateCache implements Contract
         return $this->get('total_blocks', []);
     }
 
-    public function setTotalBlocks(Closure $callback): array
+    public function setTotalBlocks(Closure $callback): void
     {
-        return $this->remember('total_blocks', now()->addHour(), $callback);
+        $this->put('total_blocks', $callback());
     }
 
     public function getTotalFees(): array
@@ -39,9 +39,9 @@ final class DelegateCache implements Contract
         return $this->get('total_fees', []);
     }
 
-    public function setTotalFees(Closure $callback): array
+    public function setTotalFees(Closure $callback): void
     {
-        return $this->remember('total_fees', now()->addHour(), $callback);
+        $this->put('total_fees', $callback());
     }
 
     public function getTotalRewards(): array
@@ -49,9 +49,9 @@ final class DelegateCache implements Contract
         return $this->get('total_rewards', []);
     }
 
-    public function setTotalRewards(Closure $callback): array
+    public function setTotalRewards(Closure $callback): void
     {
-        return $this->remember('total_rewards', now()->addHour(), $callback);
+        $this->put('total_rewards', $callback());
     }
 
     public function getTotalWalletsVoted(): int

--- a/app/Services/Cache/DelegateCache.php
+++ b/app/Services/Cache/DelegateCache.php
@@ -19,9 +19,9 @@ final class DelegateCache implements Contract
         return $this->get('total_amounts', []);
     }
 
-    public function setTotalAmounts(Closure $callback): void
+    public function setTotalAmounts(array $data): void
     {
-        $this->put('total_amounts', $callback());
+        $this->put('total_amounts', $data);
     }
 
     public function getTotalBlocks(): array
@@ -29,9 +29,9 @@ final class DelegateCache implements Contract
         return $this->get('total_blocks', []);
     }
 
-    public function setTotalBlocks(Closure $callback): void
+    public function setTotalBlocks(array $data): void
     {
-        $this->put('total_blocks', $callback());
+        $this->put('total_blocks', $data);
     }
 
     public function getTotalFees(): array
@@ -39,9 +39,9 @@ final class DelegateCache implements Contract
         return $this->get('total_fees', []);
     }
 
-    public function setTotalFees(Closure $callback): void
+    public function setTotalFees(array $data): void
     {
-        $this->put('total_fees', $callback());
+        $this->put('total_fees', $data);
     }
 
     public function getTotalRewards(): array
@@ -49,9 +49,9 @@ final class DelegateCache implements Contract
         return $this->get('total_rewards', []);
     }
 
-    public function setTotalRewards(Closure $callback): void
+    public function setTotalRewards(array $data): void
     {
-        $this->put('total_rewards', $callback());
+        $this->put('total_rewards', $data);
     }
 
     public function getTotalWalletsVoted(): int

--- a/app/Services/Cache/DelegateCache.php
+++ b/app/Services/Cache/DelegateCache.php
@@ -6,7 +6,6 @@ namespace App\Services\Cache;
 
 use App\Contracts\Cache as Contract;
 use App\Services\Cache\Concerns\ManagesCache;
-use Closure;
 use Illuminate\Cache\TaggedCache;
 use Illuminate\Support\Facades\Cache;
 

--- a/tests/Feature/Http/Controllers/ShowWalletControllerTest.php
+++ b/tests/Feature/Http/Controllers/ShowWalletControllerTest.php
@@ -19,10 +19,10 @@ it('should render the page without any errors', function () {
 
     (new NetworkCache())->setSupply(fn () => '10000000000');
 
-    ((new DelegateCache())->setTotalAmounts(fn () => [$wallet->public_key => '1000000000']));
-    ((new DelegateCache())->setTotalFees(fn () => [$wallet->public_key => '1000000000']));
-    ((new DelegateCache())->setTotalRewards(fn () => [$wallet->public_key => '1000000000']));
-    ((new DelegateCache())->setTotalBlocks(fn () => [$wallet->public_key => '1000000000']));
+    ((new DelegateCache())->setTotalAmounts([$wallet->public_key => '1000000000']));
+    ((new DelegateCache())->setTotalFees([$wallet->public_key => '1000000000']));
+    ((new DelegateCache())->setTotalRewards([$wallet->public_key => '1000000000']));
+    ((new DelegateCache())->setTotalBlocks([$wallet->public_key => '1000000000']));
 
     $this
         ->get(route('wallet', $wallet))
@@ -37,10 +37,10 @@ it('can lookup wallets by the username', function () {
 
     (new NetworkCache())->setSupply(fn () => '10000000000');
 
-    ((new DelegateCache())->setTotalAmounts(fn () => [$wallet->public_key => '1000000000']));
-    ((new DelegateCache())->setTotalFees(fn () => [$wallet->public_key => '1000000000']));
-    ((new DelegateCache())->setTotalRewards(fn () => [$wallet->public_key => '1000000000']));
-    ((new DelegateCache())->setTotalBlocks(fn () => [$wallet->public_key => '1000000000']));
+    ((new DelegateCache())->setTotalAmounts([$wallet->public_key => '1000000000']));
+    ((new DelegateCache())->setTotalFees([$wallet->public_key => '1000000000']));
+    ((new DelegateCache())->setTotalRewards([$wallet->public_key => '1000000000']));
+    ((new DelegateCache())->setTotalBlocks([$wallet->public_key => '1000000000']));
 
     expect($username)->not->toBeEmpty();
 
@@ -196,8 +196,8 @@ it('should not trim 0 at the end of votes or total forged', function () {
         ],
     ]);
 
-    (new DelegateCache())->setTotalFees(fn () => [$wallet->public_key => 234037456741]);
-    (new DelegateCache())->setTotalRewards(fn () => [$wallet->public_key => 1000000000001]);
+    (new DelegateCache())->setTotalFees([$wallet->public_key => 234037456741]);
+    (new DelegateCache())->setTotalRewards([$wallet->public_key => 1000000000001]);
 
     $this
         ->get(route('wallet', $wallet))

--- a/tests/Unit/Console/Commands/CacheDelegateAggregatesTest.php
+++ b/tests/Unit/Console/Commands/CacheDelegateAggregatesTest.php
@@ -3,13 +3,69 @@
 declare(strict_types=1);
 
 use App\Console\Commands\CacheDelegateAggregates;
+use App\Models\Block;
+use App\Models\Wallet;
 use App\Services\Cache\DelegateCache;
+use Carbon\Carbon;
 
 it('should execute the command', function () {
     (new CacheDelegateAggregates())->handle($cache = new DelegateCache());
 
-    expect($cache->getTotalAmounts())->toBeArray();
-    expect($cache->getTotalFees())->toBeArray();
-    expect($cache->getTotalRewards())->toBeArray();
-    expect($cache->getTotalBlocks())->toBeArray();
+    expect($cache->getTotalAmounts())->toBe([]);
+    expect($cache->getTotalFees())->toBe([]);
+    expect($cache->getTotalRewards())->toBe([]);
+    expect($cache->getTotalBlocks())->toBe([]);
+});
+
+it('should update cache on each run', function () {
+    $this->travelTo(Carbon::parse('2024-04-08 13:24:03'));
+
+    $cache = new DelegateCache();
+
+    expect($cache->getCache()->has(md5('total_amounts')))->toBeFalse();
+    expect($cache->getCache()->has(md5('total_blocks')))->toBeFalse();
+    expect($cache->getCache()->has(md5('total_fees')))->toBeFalse();
+    expect($cache->getCache()->has(md5('total_rewards')))->toBeFalse();
+
+    (new CacheDelegateAggregates())->handle($cache);
+
+    expect($cache->getTotalAmounts())->toBe([]);
+    expect($cache->getTotalFees())->toBe([]);
+    expect($cache->getTotalRewards())->toBe([]);
+    expect($cache->getTotalBlocks())->toBe([]);
+
+    $wallet = Wallet::factory()->activeDelegate()->create([
+        'attributes' => [
+            'delegate' => [
+                'username'       => 'delegate_1',
+                'voteBalance'    => 1234037456742,
+                'producedBlocks' => 12340,
+            ],
+        ],
+    ]);
+
+    Block::factory()->create([
+        'generator_public_key' => $wallet->public_key,
+        'total_amount'         => 123 * 1e8,
+        'total_fee'            => 3 * 1e8,
+        'reward'               => 8 * 1e8,
+    ]);
+
+    expect($cache->getCache()->has(md5('total_amounts')))->toBeTrue();
+    expect($cache->getTotalAmounts())->toBe([]);
+    expect($cache->getTotalFees())->toBe([]);
+    expect($cache->getTotalRewards())->toBe([]);
+    expect($cache->getTotalBlocks())->toBe([]);
+
+    (new CacheDelegateAggregates())->handle($cache = new DelegateCache());
+
+    expect($cache->getTotalAmounts())->toBe([$wallet->public_key => (string) intval(123 * 1e8)]);
+    expect($cache->getTotalFees())->toBe([$wallet->public_key => (string) intval(3 * 1e8)]);
+    expect($cache->getTotalRewards())->toBe([$wallet->public_key => (string) intval(8 * 1e8)]);
+    expect($cache->getTotalBlocks())->toBe([$wallet->public_key => 1]);
+
+    expect($cache->getCache()->has(md5('total_amounts')))->toBeTrue();
+    expect($cache->getCache()->has(md5('total_blocks')))->toBeTrue();
+    expect($cache->getCache()->has(md5('total_fees')))->toBeTrue();
+    expect($cache->getCache()->has(md5('total_rewards')))->toBeTrue();
 });

--- a/tests/Unit/ViewModels/WalletViewModelTest.php
+++ b/tests/Unit/ViewModels/WalletViewModelTest.php
@@ -89,8 +89,8 @@ it('should get the votes as percentage from supply', function () {
 });
 
 it('should sum up the total forged', function () {
-    (new DelegateCache())->setTotalFees(fn () => [$this->subject->publicKey() => '1000000000']);
-    (new DelegateCache())->setTotalRewards(fn () => [$this->subject->publicKey() => '1000000000']);
+    (new DelegateCache())->setTotalFees([$this->subject->publicKey() => '1000000000']);
+    (new DelegateCache())->setTotalRewards([$this->subject->publicKey() => '1000000000']);
 
     expect($this->subject->totalForged())->toBeFloat();
 
@@ -98,7 +98,7 @@ it('should sum up the total forged', function () {
 });
 
 it('should sum up the amount forged', function () {
-    (new DelegateCache())->setTotalAmounts(fn () => [$this->subject->publicKey() => '1000000000']);
+    (new DelegateCache())->setTotalAmounts([$this->subject->publicKey() => '1000000000']);
 
     expect($this->subject->amountForged())->toBeInt();
 
@@ -106,7 +106,7 @@ it('should sum up the amount forged', function () {
 });
 
 it('should sum up the fees forged', function () {
-    (new DelegateCache())->setTotalFees(fn () => [$this->subject->publicKey() => '800000000']);
+    (new DelegateCache())->setTotalFees([$this->subject->publicKey() => '800000000']);
 
     expect($this->subject->feesForged())->toBeInt();
 
@@ -114,7 +114,7 @@ it('should sum up the fees forged', function () {
 });
 
 it('should sum up the rewards forged', function () {
-    (new DelegateCache())->setTotalRewards(fn () => [$this->subject->publicKey() => '200000000']);
+    (new DelegateCache())->setTotalRewards([$this->subject->publicKey() => '200000000']);
 
     expect($this->subject->rewardsForged())->toBeInt();
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/86dt0wb60

This removes the TTL for the delegate aggregates cache data. The job itself was running minutely, but the data wasn't being updated for an hour because of how the TTL was being used. This made the job effectively redundant for 59 of the times it was run. I've changed it now so there is no expiry for the cache, but it always updates as and when the data is received. We could always have an expiry, though I don't see how useful it would be as the data will always be updated anyway (unless the cache key is changed).

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my UI changes in light AND dark mode
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
