### PR TITLE
refactor: username registration show name & resignation caching

### DIFF
--- a/app/Console/Commands/CacheUsernames.php
+++ b/app/Console/Commands/CacheUsernames.php
@@ -6,6 +6,8 @@ namespace App\Console\Commands;
 
 use App\Facades\Network;
 use App\Facades\Wallets;
+use App\Models\Scopes\UsernameResignationScope;
+use App\Models\Transaction;
 use App\Models\Wallet;
 use App\Services\Cache\WalletCache;
 use Illuminate\Console\Command;
@@ -58,6 +60,12 @@ final class CacheUsernames extends Command
                         $cache->setUsernameByPublicKey($wallet->public_key, $username);
                     }
                 }
+            });
+
+        Transaction::withScope(UsernameResignationScope::class)
+            ->each(function (Transaction $transaction) use ($cache): void {
+                $cache->forgetUsernameByAddress($transaction->sender->address);
+                $cache->forgetUsernameByPublicKey($transaction->sender->public_key);
             });
     }
 }

--- a/app/Services/Cache/Concerns/ManagesCache.php
+++ b/app/Services/Cache/Concerns/ManagesCache.php
@@ -42,6 +42,14 @@ trait ManagesCache
         return $this->getCache()->put(md5($key), $value, $ttl = null);
     }
 
+    /**
+     * @return bool
+     */
+    private function forget(string $key)
+    {
+        return $this->getCache()->forget(md5($key));
+    }
+
     private function blockTimeTTL(): int
     {
         return (int) ceil(Network::blockTime() / 2);

--- a/app/Services/Cache/WalletCache.php
+++ b/app/Services/Cache/WalletCache.php
@@ -95,6 +95,11 @@ final class WalletCache implements Contract
         $this->put(sprintf('username_by_address/%s', $address), $username);
     }
 
+    public function forgetUsernameByAddress(string $address): void
+    {
+        $this->forget(sprintf('username_by_address/%s', $address));
+    }
+
     public function getValidatorPublicKeyByAddress(string $address): ?string
     {
         return $this->get(sprintf('validator_public_key_by_address/%s', $address));
@@ -113,6 +118,11 @@ final class WalletCache implements Contract
     public function setUsernameByPublicKey(string $publicKey, string $username): void
     {
         $this->put(sprintf('username_by_public_key/%s', $publicKey), $username);
+    }
+
+    public function forgetUsernameByPublicKey(string $publicKey): void
+    {
+        $this->forget(sprintf('username_by_public_key/%s', $publicKey));
     }
 
     public function getValidator(string $publicKey): ?Wallet

--- a/app/ViewModels/Concerns/Transaction/InteractsWithUsernames.php
+++ b/app/ViewModels/Concerns/Transaction/InteractsWithUsernames.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\ViewModels\Concerns\Transaction;
 
 use Illuminate\Support\Arr;

--- a/app/ViewModels/Concerns/Transaction/InteractsWithUsernames.php
+++ b/app/ViewModels/Concerns/Transaction/InteractsWithUsernames.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\ViewModels\Concerns\Transaction;
+
+use Illuminate\Support\Arr;
+
+trait InteractsWithUsernames
+{
+    public function username(): ?string
+    {
+        return Arr::get($this->transaction, 'asset.username');
+    }
+}

--- a/app/ViewModels/TransactionViewModel.php
+++ b/app/ViewModels/TransactionViewModel.php
@@ -20,6 +20,7 @@ use App\ViewModels\Concerns\Transaction\InteractsWithEntities;
 use App\ViewModels\Concerns\Transaction\InteractsWithMultiPayment;
 use App\ViewModels\Concerns\Transaction\InteractsWithMultiSignature;
 use App\ViewModels\Concerns\Transaction\InteractsWithTypeData;
+use App\ViewModels\Concerns\Transaction\InteractsWithUsernames;
 use App\ViewModels\Concerns\Transaction\InteractsWithValidatorRegistration;
 use App\ViewModels\Concerns\Transaction\InteractsWithVendorField;
 use App\ViewModels\Concerns\Transaction\InteractsWithVotes;
@@ -38,6 +39,7 @@ final class TransactionViewModel implements ViewModel
     use InteractsWithMultiPayment;
     use InteractsWithMultiSignature;
     use InteractsWithTypeData;
+    use InteractsWithUsernames;
     use InteractsWithVendorField;
     use InteractsWithVotes;
     use InteractsWithWallets;

--- a/database/factories/WalletFactory.php
+++ b/database/factories/WalletFactory.php
@@ -16,21 +16,19 @@ final class WalletFactory extends Factory
         $wallet = $this->faker->wallet;
 
         return [
-            'id'                => $this->faker->uuid,
-            'address'           => $wallet['address'],
-            'public_key'        => $wallet['publicKey'],
-            'balance'           => $this->faker->numberBetween(1, 1000) * 1e8,
-            'nonce'             => $this->faker->numberBetween(1, 1000),
-            'attributes'        => [
-                'secondPublicKey'  => $this->faker->publicKey,
-                'validator'        => [
-                    'username'       => $this->faker->userName,
-                    'voteBalance'    => $this->faker->numberBetween(1, 1000) * 1e8,
-                    'producedBlocks' => $this->faker->numberBetween(1, 1000),
-                    'missedBlocks'   => $this->faker->numberBetween(1, 1000),
-                ],
+            'id'         => $this->faker->uuid,
+            'address'    => $wallet['address'],
+            'public_key' => $wallet['publicKey'],
+            'balance'    => $this->faker->numberBetween(1, 1000) * 1e8,
+            'nonce'      => $this->faker->numberBetween(1, 1000),
+            'attributes' => [
+                'secondPublicKey'         => $this->faker->publicKey,
+                'username'                => $this->faker->userName,
+                'validatorVoteBalance'    => $this->faker->numberBetween(1, 1000) * 1e8,
+                'validatorProducedBlocks' => $this->faker->numberBetween(1, 1000),
+                'validatorMissedBlocks'   => $this->faker->numberBetween(1, 1000),
             ],
-            'updated_at'       => $this->faker->dateTimeBetween('-1 year', 'now'),
+            'updated_at' => $this->faker->dateTimeBetween('-1 year', 'now'),
         ];
     }
 
@@ -38,14 +36,12 @@ final class WalletFactory extends Factory
     {
         return $this->state(function () {
             return [
-                'attributes'        => [
-                    'validator'        => [
-                        'rank'           => $this->faker->numberBetween(1, 51),
-                        'username'       => $this->faker->userName,
-                        'voteBalance'    => $this->faker->numberBetween(1, 1000) * 1e8,
-                        'producedBlocks' => $this->faker->numberBetween(1, 1000),
-                        'missedBlocks'   => $this->faker->numberBetween(1, 1000),
-                    ],
+                'attributes' => [
+                    'username'                => $this->faker->userName,
+                    'validatorRank'           => $this->faker->numberBetween(1, 51),
+                    'validatorVoteBalance'    => $this->faker->numberBetween(1, 1000) * 1e8,
+                    'validatorProducedBlocks' => $this->faker->numberBetween(1, 1000),
+                    'validatorMissedBlocks'   => $this->faker->numberBetween(1, 1000),
                 ],
             ];
         });
@@ -55,15 +51,13 @@ final class WalletFactory extends Factory
     {
         return $this->state(function () use ($isResigned) {
             return [
-                'attributes'        => [
-                    'validator'        => [
-                        'resigned'       => $isResigned,
-                        'rank'           => $this->faker->numberBetween(52, 102),
-                        'username'       => $this->faker->userName,
-                        'voteBalance'    => $this->faker->numberBetween(1, 100) * 1e8,
-                        'producedBlocks' => $this->faker->numberBetween(1, 1000),
-                        'missedBlocks'   => $this->faker->numberBetween(1, 1000),
-                    ],
+                'attributes' => [
+                    'username'                => $this->faker->userName,
+                    'validatorResigned'       => $isResigned,
+                    'validatorRank'           => $this->faker->numberBetween(52, 102),
+                    'validatorVoteBalance'    => $this->faker->numberBetween(1, 100) * 1e8,
+                    'validatorProducedBlocks' => $this->faker->numberBetween(1, 1000),
+                    'validatorMissedBlocks'   => $this->faker->numberBetween(1, 1000),
                 ],
             ];
         });

--- a/resources/views/components/transaction/page/transaction-type.blade.php
+++ b/resources/views/components/transaction/page/transaction-type.blade.php
@@ -65,7 +65,7 @@
     @elseif ($transaction->isUsernameRegistration() || $transaction->isUsernameResignation())
         <x-transaction.page.section-detail.row
             :title="trans('pages.transaction.header.username')"
-            :value="$transaction->sender()->username()"
+            :value="$transaction->username()"
             :transaction="$transaction"
         />
     @elseif ($transaction->isLegacy())

--- a/tests/Unit/Console/Commands/CacheUsernamesTest.php
+++ b/tests/Unit/Console/Commands/CacheUsernamesTest.php
@@ -3,13 +3,17 @@
 declare(strict_types=1);
 
 use App\Console\Commands\CacheUsernames;
+use App\Models\Transaction;
 use App\Models\Wallet;
+use App\Services\Cache\WalletCache;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Http;
 
 it('should cache the username for the public key', function () {
-    $wallet = Wallet::factory()->create();
+    $wallet = Wallet::factory()->create([
+        'attributes->username' => 'testuser',
+    ]);
 
     expect(Cache::tags('wallet')->has(md5("username_by_address/$wallet->address")))->toBeFalse();
     expect(Cache::tags('wallet')->has(md5("username_by_public_key/$wallet->public_key")))->toBeFalse();
@@ -41,7 +45,7 @@ it('should cache the known wallet name if defined', function () {
     ]);
 
     $regularWallet = Wallet::factory()->create([
-        'attributes->validator->username' => 'regular',
+        'attributes->username' => 'regular',
     ]);
 
     (new CacheUsernames())->handle();
@@ -64,11 +68,33 @@ it('should cache the known wallet name if doesnt have validator name', function 
     ], 200));
 
     $wallet = Wallet::factory()->create([
-        'address'                         => 'AagJoLEnpXYkxYdYkmdDSNMLjjBkLJ6T67',
-        'attributes->validator->username' => null,
+        'address'              => 'AagJoLEnpXYkxYdYkmdDSNMLjjBkLJ6T67',
+        'attributes->username' => null,
     ]);
 
     (new CacheUsernames())->handle();
 
     expect(Cache::tags('wallet')->get(md5("username_by_address/$wallet->address")))->toBe('Hot Wallet');
+});
+
+it('should forget wallets with resigned usernames', function () {
+    $cache  = new WalletCache();
+    $wallet = Wallet::factory()->create([
+        'address'              => 'AagJoLEnpXYkxYdYkmdDSNMLjjBkLJ6T67',
+        'attributes->username' => 'joeblogs',
+    ]);
+
+    (new CacheUsernames())->handle();
+
+    expect($cache->getUsernameByAddress($wallet->address))->toBe('joeblogs');
+    expect($cache->getUsernameByPublicKey($wallet->public_key))->toBe('joeblogs');
+
+    Transaction::factory()->usernameResignation()->create([
+        'sender_public_key' => $wallet->public_key,
+    ]);
+
+    (new CacheUsernames())->handle();
+
+    expect($cache->getUsernameByAddress($wallet->address))->toBeNull();
+    expect($cache->getUsernameByPublicKey($wallet->public_key))->toBeNull();
 });


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/86dt3eecx

To test:

- Register a username on a wallet
- Run `php artisan explorer:cache-usernames`
- Username should be shown in UI (wallet page, tx list, etc)
- Resign username
- Run `php artisan explorer:cache-usernames`
- Should no longer show username (apart from on the Username Registration transaction page)

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my UI changes in light AND dark mode
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
