### PR TITLE
fix: pricing fetch from coingecko

### DIFF
--- a/app/Services/MarketDataProviders/CoinGecko.php
+++ b/app/Services/MarketDataProviders/CoinGecko.php
@@ -24,7 +24,7 @@ final class CoinGecko extends AbstractMarketDataProvider
         return $cache->setHistorical($source, $target, $format, function () use ($source, $target, $format, $cache): Collection {
             $params = [
                 'vs_currency' => Str::lower($target),
-                'days'        => Network::epoch()->diffInDays() + 1, // +1 to handle edge case where first day is not returned in full depending on time of day
+                'days'        => min(365, Network::epoch()->diffInDays() + 1), // +1 to handle edge case where first day is not returned in full depending on time of day
                 'interval'    => 'daily',
             ];
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/86dt4cwyj

It seems coingecko have _potentially_ changed their API. The market chart endpoint has a max "days" of 365, which we didn't have a problem with previously. It gives this error currently:

>Your request exceeds the allowed time range. Public API users are limited to querying historical data within the past 365 days.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my UI changes in light AND dark mode
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
