### PR TITLE
refactor: show address if no username

### DIFF
--- a/resources/js/wallet.js
+++ b/resources/js/wallet.js
@@ -136,7 +136,12 @@ const Wallet = (network, xData = {}) => {
                 return null;
             }
 
-            return this.votingFor.attributes?.delegate?.username;
+            const username = this.votingFor.attributes?.username;
+            if (username) {
+                return username;
+            }
+
+            return truncateMiddle(this.votingForAddress);
         },
 
         async storeData() {

--- a/resources/js/wallet.js
+++ b/resources/js/wallet.js
@@ -136,7 +136,7 @@ const Wallet = (network, xData = {}) => {
                 return null;
             }
 
-            const username = this.votingFor.attributes?.username;
+            const username = this.votingFor.attributes?.delegate?.username;
             if (username) {
                 return username;
             }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/86dtdxn2y

Can't test with mainsail yet so to test:

edit `resources/views/components/arkconnect/standby-delegate-toast.blade.php` like 3 to the below
```
show-property="true"
```

comment out `resources/js/wallet.js` like 141

This will show the standby toast message. It will briefly show no name or address as it's skipping some checks where it may not have fetched the voted delegate yet. In production it will show the popup after the voted delegate has been loaded

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my UI changes in light AND dark mode
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
