### PR TITLE
refactor: annual statistics command

### DIFF
--- a/app/Console/Commands/CacheAnnualStatistics.php
+++ b/app/Console/Commands/CacheAnnualStatistics.php
@@ -19,7 +19,7 @@ final class CacheAnnualStatistics extends Command
      *
      * @var string
      */
-    protected $signature = 'explorer:cache-annual-statistics {--all}}';
+    protected $signature = 'explorer:cache-annual-statistics {--all}';
 
     /**
      * The console command description.

--- a/app/Console/Commands/CacheAnnualStatistics.php
+++ b/app/Console/Commands/CacheAnnualStatistics.php
@@ -30,15 +30,21 @@ final class CacheAnnualStatistics extends Command
 
     public function handle(StatisticsCache $cache): void
     {
-        if ($this->option('all')) {
-            $this->cacheAllYears($cache);
-        } else {
-            $this->cacheCurrentYear($cache);
-        }
+        $this->cacheAllYears($cache);
+        $this->cacheCurrentYear($cache);
+    }
+
+    private function hasCachedAll(StatisticsCache $cache): bool
+    {
+        return $cache->getAnnualData(Network::epoch()->year) !== null;
     }
 
     private function cacheAllYears(StatisticsCache $cache): void
     {
+        if ($this->hasCachedAll($cache) && $this->option('all') === false) {
+            return;
+        }
+
         $epoch           = Network::epoch()->timestamp;
         $transactionData = DB::connection('explorer')
             ->query()

--- a/tests/Unit/Console/Commands/CacheAnnualStatisticsTest.php
+++ b/tests/Unit/Console/Commands/CacheAnnualStatisticsTest.php
@@ -110,3 +110,125 @@ it('should handle null scenarios for annual data for all time', function () {
 
     expect($cache->getAnnualData(2017))->toBeNull();
 });
+
+it('should get all annual data if not already set', function () {
+    $cache = new StatisticsCache();
+
+    expect($cache->getAnnualData(2017))->toBeNull();
+
+    // 2017
+    Transaction::factory()->count(6)->create([
+        'timestamp' => 1,
+        'amount'    => 10 * 1e8,
+        'fee'       => 0.1 * 1e8,
+    ]);
+    Block::factory()->count(6)->create([
+        'timestamp' => 1,
+    ]);
+
+    $this->artisan('explorer:cache-annual-statistics');
+
+    expect($cache->getAnnualData(2017))->toBe([
+        'year'         => 2017,
+        'transactions' => 6,
+        'volume'       => '60.0000000000000000',
+        'fees'         => '0.60000000000000000000',
+        'blocks'       => 6,
+    ]);
+});
+
+it('should not cache all annual data if already set', function () {
+    $cache = new StatisticsCache();
+
+    expect($cache->getAnnualData(2017))->toBeNull();
+    expect($cache->getAnnualData(2018))->toBeNull();
+    expect($cache->getAnnualData(2019))->toBeNull();
+    expect($cache->getAnnualData(2020))->toBeNull();
+    expect($cache->getAnnualData(2021))->toBeNull();
+    expect($cache->getAnnualData(2022))->toBeNull();
+    expect($cache->getAnnualData(2023))->toBeNull();
+
+    $cache->setAnnualData(2017, 6, '60.0000000000000000', '0.60000000000000000000', 6);
+
+    expect($cache->getAnnualData(2017))->not->toBeNull();
+    expect($cache->getAnnualData(2018))->toBeNull();
+    expect($cache->getAnnualData(2019))->toBeNull();
+    expect($cache->getAnnualData(2020))->toBeNull();
+    expect($cache->getAnnualData(2021))->toBeNull();
+    expect($cache->getAnnualData(2022))->toBeNull();
+    expect($cache->getAnnualData(2023))->toBeNull();
+
+    // 2020, default timestamp. Needed as transaction factory will create blocks in addition
+    Transaction::factory()->count(3)->create();
+    Block::factory()->create();
+    Transaction::factory()->multiPayment()->count(3)->create([
+        'amount' => 0,
+        'asset'  => ['payments' => [['amount' => 10 * 1e8, 'recipientId' => 'Wallet1'], ['amount' => 1 * 1e8, 'recipientId' => 'Wallet2']]],
+    ]);
+
+    $this->artisan('explorer:cache-annual-statistics');
+
+    expect($cache->getAnnualData(2017))->not->toBeNull();
+    expect($cache->getAnnualData(2018))->toBeNull();
+    expect($cache->getAnnualData(2019))->toBeNull();
+    expect($cache->getAnnualData(2020))->toBeNull();
+    expect($cache->getAnnualData(2021))->toBeNull();
+    expect($cache->getAnnualData(2022))->toBeNull();
+    expect($cache->getAnnualData(2023))->toBeNull();
+
+    expect($cache->getAnnualData(2024))->toBe([
+        'year'         => 2024,
+        'transactions' => 0,
+        'volume'       => '0',
+        'fees'         => '0',
+        'blocks'       => 0,
+    ]);
+});
+
+it('should cache all annual data with flag even if not already set', function () {
+    $cache = new StatisticsCache();
+
+    expect($cache->getAnnualData(2017))->toBeNull();
+    expect($cache->getAnnualData(2018))->toBeNull();
+    expect($cache->getAnnualData(2019))->toBeNull();
+    expect($cache->getAnnualData(2020))->toBeNull();
+    expect($cache->getAnnualData(2021))->toBeNull();
+    expect($cache->getAnnualData(2022))->toBeNull();
+    expect($cache->getAnnualData(2023))->toBeNull();
+
+    $cache->setAnnualData(2017, 6, '60.0000000000000000', '0.60000000000000000000', 6);
+
+    expect($cache->getAnnualData(2017))->not->toBeNull();
+    expect($cache->getAnnualData(2018))->toBeNull();
+    expect($cache->getAnnualData(2019))->toBeNull();
+    expect($cache->getAnnualData(2020))->toBeNull();
+    expect($cache->getAnnualData(2021))->toBeNull();
+    expect($cache->getAnnualData(2022))->toBeNull();
+    expect($cache->getAnnualData(2023))->toBeNull();
+
+    // 2020, default timestamp. Needed as transaction factory will create blocks in addition
+    Transaction::factory()->count(3)->create();
+    Block::factory()->create();
+    Transaction::factory()->multiPayment()->count(3)->create([
+        'amount' => 0,
+        'asset'  => ['payments' => [['amount' => 10 * 1e8, 'recipientId' => 'Wallet1'], ['amount' => 1 * 1e8, 'recipientId' => 'Wallet2']]],
+    ]);
+
+    $this->artisan('explorer:cache-annual-statistics --all');
+
+    expect($cache->getAnnualData(2017))->not->toBeNull();
+    expect($cache->getAnnualData(2018))->toBeNull();
+    expect($cache->getAnnualData(2019))->toBeNull();
+    expect($cache->getAnnualData(2020))->not->toBeNull();
+    expect($cache->getAnnualData(2021))->toBeNull();
+    expect($cache->getAnnualData(2022))->toBeNull();
+    expect($cache->getAnnualData(2023))->toBeNull();
+
+    expect($cache->getAnnualData(2024))->toBe([
+        'year'         => 2024,
+        'transactions' => 0,
+        'volume'       => '0',
+        'fees'         => '0',
+        'blocks'       => 0,
+    ]);
+});


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/86dthqywa

The command now checks if there's data from the epoch year (e.g. 2017). If it is, it won't cache annual data automatically. This can be bypassed still with the `--all` flag.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my UI changes in light AND dark mode
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
