### PR TITLE
fix: arkconnect delegate voting for indicator

### DIFF
--- a/resources/views/components/tables/desktop/delegates/list-table.blade.php
+++ b/resources/views/components/tables/desktop/delegates/list-table.blade.php
@@ -81,7 +81,10 @@
                         />
 
                         @if (config('arkscan.arkconnect.enabled'))
-                            <div x-show="votingForAddress === '{{ $delegate->address() }}'">
+                            <div
+                                x-data="{}"
+                                x-show="votingForAddress === '{{ $delegate->address() }}'"
+                            >
                                 <div data-tippy-content="@lang('pages.delegates.arkconnect.voting_for_tooltip')">
                                     <x-ark-icon
                                         name="check-mark-box"


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/86dtjd1n1

Don't really understand the root cause of this. The table row itself has a `wire:key` so it's not confusing it with other rows. I took it as an alpinejs oddity, and the issue seemed to disappear once I forced it to initiate some kind of alpine logic on the element that shows the voting indicator.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my UI changes in light AND dark mode
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
