### PR TITLE
refactor: statistics latest wallet ignore sender

### DIFF
--- a/app/Services/Addresses/Aggregates/LatestWalletAggregate.php
+++ b/app/Services/Addresses/Aggregates/LatestWalletAggregate.php
@@ -21,8 +21,7 @@ final class LatestWalletAggregate
         $newestQuery = Wallet::query()
             ->select('wallets.address', DB::raw('MIN(transactions.timestamp) as timestamp'))
             ->leftJoin('transactions', function ($join) {
-                $join->on('wallets.public_key', '=', 'transactions.sender_public_key')
-                    ->orOn('wallets.address', '=', 'transactions.recipient_id');
+                $join->orOn('wallets.address', '=', 'transactions.recipient_id');
             })
             ->whereNotNull('transactions.sender_public_key')
             ->whereNotNull('transactions.recipient_id')

--- a/app/Services/Addresses/Aggregates/LatestWalletAggregate.php
+++ b/app/Services/Addresses/Aggregates/LatestWalletAggregate.php
@@ -21,7 +21,7 @@ final class LatestWalletAggregate
         $newestQuery = Wallet::query()
             ->select('wallets.address', DB::raw('MIN(transactions.timestamp) as timestamp'))
             ->leftJoin('transactions', function ($join) {
-                $join->orOn('wallets.address', '=', 'transactions.recipient_id');
+                $join->on('wallets.address', '=', 'transactions.recipient_id');
             })
             ->whereNotNull('transactions.sender_public_key')
             ->whereNotNull('transactions.recipient_id')

--- a/tests/Unit/Services/Addresses/Aggregates/LatestWalletAggregateTest.php
+++ b/tests/Unit/Services/Addresses/Aggregates/LatestWalletAggregateTest.php
@@ -1,0 +1,49 @@
+<?php
+
+use App\Models\Transaction;
+use App\Models\Wallet;
+use App\Services\Addresses\Aggregates\LatestWalletAggregate;
+use App\Services\Cache\StatisticsCache;
+use App\Services\Timestamp;
+use Carbon\Carbon;
+
+it('should refresh the latest wallet', function () {
+    $cache = new StatisticsCache();
+
+    expect($cache->getNewestAddress())->toBeNull();
+
+    $genesisWallet = Wallet::factory()->create();
+    $newestWallet = Wallet::factory()->create();
+
+    $genesisTimestamp = Timestamp::fromUnix(Carbon::parse('2021-01-01 13:24:44')->unix())->unix();
+
+    Transaction::factory()->transfer()->create([
+        'sender_public_key' => $genesisWallet->public_key,
+        'recipient_id'      => $newestWallet->address,
+        'timestamp'         => $genesisTimestamp,
+    ]);
+
+    (new LatestWalletAggregate())->aggregate();
+
+    expect($cache->getNewestAddress())->toBe([
+        'address'   => $newestWallet->address,
+        'timestamp' => $genesisTimestamp,
+        'value'     => '01 Jan 2021',
+    ]);
+
+    $newestTimestamp = Timestamp::fromUnix(Carbon::parse('2021-01-01 14:24:44')->unix())->unix();
+
+    Transaction::factory()->transfer()->create([
+        'sender_public_key' => $newestWallet->public_key,
+        'recipient_id'      => $newestWallet->address,
+        'timestamp'         => $newestTimestamp,
+    ]);
+
+    (new LatestWalletAggregate())->aggregate();
+
+    expect($cache->getNewestAddress())->toBe([
+        'address'   => $newestWallet->address,
+        'timestamp' => $genesisTimestamp,
+        'value'     => '01 Jan 2021',
+    ]);
+});

--- a/tests/Unit/Services/Addresses/Aggregates/LatestWalletAggregateTest.php
+++ b/tests/Unit/Services/Addresses/Aggregates/LatestWalletAggregateTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use App\Models\Transaction;
 use App\Models\Wallet;
 use App\Services\Addresses\Aggregates\LatestWalletAggregate;
@@ -13,7 +15,7 @@ it('should refresh the latest wallet', function () {
     expect($cache->getNewestAddress())->toBeNull();
 
     $genesisWallet = Wallet::factory()->create();
-    $newestWallet = Wallet::factory()->create();
+    $newestWallet  = Wallet::factory()->create();
 
     $genesisTimestamp = Timestamp::fromUnix(Carbon::parse('2021-01-01 13:24:44')->unix())->unix();
 

--- a/tests/Unit/Services/Addresses/Aggregates/LatestWalletAggregateTest.php
+++ b/tests/Unit/Services/Addresses/Aggregates/LatestWalletAggregateTest.php
@@ -17,7 +17,7 @@ it('should refresh the latest wallet - A > B', function () {
 
     expect($cache->getNewestAddress())->toBeNull();
 
-    $walletA = Wallet::factory()->create(['address' => 'wallet-a']);
+    $walletA  = Wallet::factory()->create(['address' => 'wallet-a']);
     $walletB  = Wallet::factory()->create(['address' => 'wallet-b']);
 
     Transaction::factory()->transfer()->create([
@@ -53,7 +53,7 @@ it('should refresh the latest wallet - A > B > C', function () {
 
     expect($cache->getNewestAddress())->toBeNull();
 
-    $walletA = Wallet::factory()->create(['address' => 'wallet-a']);
+    $walletA  = Wallet::factory()->create(['address' => 'wallet-a']);
     $walletB  = Wallet::factory()->create(['address' => 'wallet-b']);
     $walletC  = Wallet::factory()->create(['address' => 'wallet-c']);
 
@@ -108,7 +108,7 @@ it('should refresh the latest wallet - A > B > existing C', function () {
 
     expect($cache->getNewestAddress())->toBeNull();
 
-    $walletA = Wallet::factory()->create(['address' => 'wallet-a']);
+    $walletA  = Wallet::factory()->create(['address' => 'wallet-a']);
     $walletB  = Wallet::factory()->create(['address' => 'wallet-b']);
     $walletC  = Wallet::factory()->create(['address' => 'wallet-c']);
 
@@ -171,7 +171,7 @@ it('should refresh the latest wallet - A > multipayment B', function () {
 
     expect($cache->getNewestAddress())->toBeNull();
 
-    $walletA = Wallet::factory()->create(['address' => 'wallet-a']);
+    $walletA  = Wallet::factory()->create(['address' => 'wallet-a']);
     $walletB  = Wallet::factory()->create(['address' => 'wallet-b']);
 
     Transaction::factory()->transfer()->create([

--- a/tests/Unit/Services/Addresses/Aggregates/LatestWalletAggregateTest.php
+++ b/tests/Unit/Services/Addresses/Aggregates/LatestWalletAggregateTest.php
@@ -9,26 +9,74 @@ use App\Services\Cache\StatisticsCache;
 use App\Services\Timestamp;
 use Carbon\Carbon;
 
-it('should refresh the latest wallet', function () {
-    $cache = new StatisticsCache();
+it('should refresh the latest wallet - A > B', function () {
+    $this->travelTo('2021-01-01 11:24:44');
+
+    $cache     = new StatisticsCache();
+    $aggregate = new LatestWalletAggregate();
 
     expect($cache->getNewestAddress())->toBeNull();
 
-    $genesisWallet = Wallet::factory()->create();
-    $newestWallet  = Wallet::factory()->create();
+    $walletA = Wallet::factory()->create(['address' => 'wallet-a']);
+    $walletB  = Wallet::factory()->create(['address' => 'wallet-b']);
+
+    Transaction::factory()->transfer()->create([
+        'sender_public_key' => $walletA->public_key,
+        'recipient_id'      => $walletA->address,
+        'timestamp'         => 0,
+    ]);
 
     $genesisTimestamp = Timestamp::fromUnix(Carbon::parse('2021-01-01 13:24:44')->unix())->unix();
 
     Transaction::factory()->transfer()->create([
-        'sender_public_key' => $genesisWallet->public_key,
-        'recipient_id'      => $newestWallet->address,
+        'sender_public_key' => $walletA->public_key,
+        'recipient_id'      => $walletB->address,
         'timestamp'         => $genesisTimestamp,
     ]);
 
-    (new LatestWalletAggregate())->aggregate();
+    $result = $aggregate->aggregate();
+    expect($result)->not->toBeNull();
+    expect($result->address)->toBe($walletB->address);
 
     expect($cache->getNewestAddress())->toBe([
-        'address'   => $newestWallet->address,
+        'address'   => $walletB->address,
+        'timestamp' => $genesisTimestamp,
+        'value'     => '01 Jan 2021',
+    ]);
+});
+
+it('should refresh the latest wallet - A > B > C', function () {
+    $this->travelTo('2021-01-01 11:24:44');
+
+    $cache     = new StatisticsCache();
+    $aggregate = new LatestWalletAggregate();
+
+    expect($cache->getNewestAddress())->toBeNull();
+
+    $walletA = Wallet::factory()->create(['address' => 'wallet-a']);
+    $walletB  = Wallet::factory()->create(['address' => 'wallet-b']);
+    $walletC  = Wallet::factory()->create(['address' => 'wallet-c']);
+
+    Transaction::factory()->transfer()->create([
+        'sender_public_key' => $walletA->public_key,
+        'recipient_id'      => $walletA->address,
+        'timestamp'         => 0,
+    ]);
+
+    $genesisTimestamp = Timestamp::fromUnix(Carbon::parse('2021-01-01 13:24:44')->unix())->unix();
+
+    Transaction::factory()->transfer()->create([
+        'sender_public_key' => $walletA->public_key,
+        'recipient_id'      => $walletB->address,
+        'timestamp'         => $genesisTimestamp,
+    ]);
+
+    $result = $aggregate->aggregate();
+    expect($result)->not->toBeNull();
+    expect($result->address)->toBe($walletB->address);
+
+    expect($cache->getNewestAddress())->toBe([
+        'address'   => $walletB->address,
         'timestamp' => $genesisTimestamp,
         'value'     => '01 Jan 2021',
     ]);
@@ -36,16 +84,126 @@ it('should refresh the latest wallet', function () {
     $newestTimestamp = Timestamp::fromUnix(Carbon::parse('2021-01-01 14:24:44')->unix())->unix();
 
     Transaction::factory()->transfer()->create([
-        'sender_public_key' => $newestWallet->public_key,
-        'recipient_id'      => $newestWallet->address,
+        'sender_public_key' => $walletB->public_key,
+        'recipient_id'      => $walletC->address,
         'timestamp'         => $newestTimestamp,
     ]);
 
-    (new LatestWalletAggregate())->aggregate();
+    $result = $aggregate->aggregate();
+    expect($result)->not->toBeNull();
+    expect($result->address)->toBe($walletC->address);
 
     expect($cache->getNewestAddress())->toBe([
-        'address'   => $newestWallet->address,
+        'address'   => $walletC->address,
+        'timestamp' => $newestTimestamp,
+        'value'     => '01 Jan 2021',
+    ]);
+});
+
+it('should refresh the latest wallet - A > B > existing C', function () {
+    $this->travelTo('2021-01-01 11:24:44');
+
+    $cache     = new StatisticsCache();
+    $aggregate = new LatestWalletAggregate();
+
+    expect($cache->getNewestAddress())->toBeNull();
+
+    $walletA = Wallet::factory()->create(['address' => 'wallet-a']);
+    $walletB  = Wallet::factory()->create(['address' => 'wallet-b']);
+    $walletC  = Wallet::factory()->create(['address' => 'wallet-c']);
+
+    Transaction::factory()->transfer()->create([
+        'sender_public_key' => $walletA->public_key,
+        'recipient_id'      => $walletA->address,
+        'timestamp'         => 0,
+    ]);
+
+    $existingTimestamp = Timestamp::fromUnix(Carbon::parse('2021-01-01 12:24:44')->unix())->unix();
+
+    Transaction::factory()->transfer()->create([
+        'sender_public_key' => $walletC->public_key,
+        'recipient_id'      => $walletC->address,
+        'timestamp'         => $existingTimestamp,
+    ]);
+
+    $genesisTimestamp = Timestamp::fromUnix(Carbon::parse('2021-01-01 13:24:44')->unix())->unix();
+
+    Transaction::factory()->transfer()->create([
+        'sender_public_key' => $walletA->public_key,
+        'recipient_id'      => $walletB->address,
+        'timestamp'         => $genesisTimestamp,
+    ]);
+
+    $result = $aggregate->aggregate();
+    expect($result)->not->toBeNull();
+    expect($result->address)->toBe($walletB->address);
+
+    expect($cache->getNewestAddress())->toBe([
+        'address'   => $walletB->address,
+        'timestamp' => $genesisTimestamp,
+        'value'     => '01 Jan 2021',
+    ]);
+
+    $newestTimestamp = Timestamp::fromUnix(Carbon::parse('2021-01-01 14:24:44')->unix())->unix();
+
+    Transaction::factory()->transfer()->create([
+        'sender_public_key' => $walletB->public_key,
+        'recipient_id'      => $walletC->address,
+        'timestamp'         => $newestTimestamp,
+    ]);
+
+    $result = $aggregate->aggregate();
+    expect($result)->not->toBeNull();
+    expect($result->address)->toBe($walletB->address);
+
+    expect($cache->getNewestAddress())->toBe([
+        'address'   => $walletB->address,
         'timestamp' => $genesisTimestamp,
         'value'     => '01 Jan 2021',
     ]);
 });
+
+it('should refresh the latest wallet - A > multipayment B', function () {
+    $this->travelTo('2021-01-01 11:24:44');
+
+    $cache     = new StatisticsCache();
+    $aggregate = new LatestWalletAggregate();
+
+    expect($cache->getNewestAddress())->toBeNull();
+
+    $walletA = Wallet::factory()->create(['address' => 'wallet-a']);
+    $walletB  = Wallet::factory()->create(['address' => 'wallet-b']);
+
+    Transaction::factory()->transfer()->create([
+        'sender_public_key' => $walletA->public_key,
+        'recipient_id'      => $walletA->address,
+        'timestamp'         => 0,
+    ]);
+
+    $genesisTimestamp = Timestamp::fromUnix(Carbon::parse('2021-01-01 13:24:44')->unix())->unix();
+
+    Transaction::factory()->transfer()->create([
+        'sender_public_key' => $walletA->public_key,
+        'recipient_id'      => $walletA->address,
+        'timestamp'         => $genesisTimestamp,
+
+        'asset' => [
+            'payments' => [
+                [
+                    'recipientId' => $walletB->address,
+                    'amount'      => 1 * 1e8,
+                ],
+            ],
+        ],
+    ]);
+
+    $result = $aggregate->aggregate();
+    expect($result)->not->toBeNull();
+    expect($result->address)->toBe($walletB->address);
+
+    expect($cache->getNewestAddress())->toBe([
+        'address'   => $walletB->address,
+        'timestamp' => $genesisTimestamp,
+        'value'     => '01 Jan 2021',
+    ]);
+})->skip('This test is not yet implemented.');


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Related to https://app.clickup.com/t/86dtwxpzh

An observation I made where the wrong wallet is picked up as the latest. This is while running a local testnet, it would pick up the original sender as the newest and not the receiver

**note: I did enable `CORE_WALLET_SYNC_ENABLED` on my testnet prior to this change. I don't know if this enables storing cold wallets also, and whether the Explorer nodes have it enabled as well**

Edit: added additional tests to ensure everything works as expected

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my UI changes in light AND dark mode
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
