### PR TITLE
chore: use phpunit cache on github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,6 +151,12 @@ jobs:
               env:
                   PGPASSWORD: password
 
+            - name: Cache PHPUnit coverage
+              uses: actions/cache@v4
+              with:
+                  path: .phpunit.cache
+                  key: phpunit-cache-${{ runner.os }}-${{ hashFiles('composer.json') }}
+
             - name: Run Tests
               run: composer test:coverage
               env:

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ coverage.xml
 auth.json
 TxtVoteReport.txt
 .env.testing
+/.phpunit.cache


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Adds the `.phpunit.cache` folder to `.gitignore` to prevent a bunch of untracked files from appearing locally when running test:coverage. It also updates the GitHub Actions workflow to cache the .phpunit.cache directory, allowing us to benefit from faster subsequent test runs.

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my UI changes in light AND dark mode
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
