### PR TITLE
fix: history pagination reset

### DIFF
--- a/app/Http/Livewire/Concerns/HasTableFilter.php
+++ b/app/Http/Livewire/Concerns/HasTableFilter.php
@@ -53,12 +53,17 @@ trait HasTableFilter
         }
     }
 
-    public function updatedFilter(bool $value, string $key): void
+    public function updatingFilter(bool $value, string $key): void
+    {
+        if (Arr::get($this->filter, $key) === $value) {
+            return;
+        }
+
+        $this->gotoPage(1);
+    }
+
+    public function updatedFilter(): void
     {
         $this->selectAllFilters = $this->isAllSelected;
-
-        if (Arr::get($this->filter, $key) !== $value) {
-            $this->setPage(1);
-        }
     }
 }

--- a/app/Http/Livewire/Concerns/HasTableFilter.php
+++ b/app/Http/Livewire/Concerns/HasTableFilter.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Http\Livewire\Concerns;
 
+use Illuminate\Support\Arr;
+
 trait HasTableFilter
 {
     public bool $selectAllFilters = true;
@@ -51,10 +53,12 @@ trait HasTableFilter
         }
     }
 
-    public function updatedFilter(): void
+    public function updatedFilter(bool $value, string $key): void
     {
         $this->selectAllFilters = $this->isAllSelected;
 
-        $this->setPage(1);
+        if (Arr::get($this->filter, $key) !== $value) {
+            $this->setPage(1);
+        }
     }
 }

--- a/resources/views/components/general/encapsulated/amount-fiat-tooltip.blade.php
+++ b/resources/views/components/general/encapsulated/amount-fiat-tooltip.blade.php
@@ -1,3 +1,5 @@
+@use('\Brick\Math\BigDecimal')
+
 @props([
     'transaction' => null,
     'wallet' => null,
@@ -15,6 +17,9 @@
     $sentToSelfClass = null;
 
     $isSentToSelf = $amountForItself !== null && $amountForItself > 0;
+
+    $isAllSentToSelf =  $amountForItself !== null ? BigDecimal::of((string) $amountForItself)->isEqualTo(BigDecimal::of((string) $amount)) : false;
+
     if (! $withoutStyling) {
         if(! $isSent && ! $isReceived) {
             $class[] = 'text-theme-secondary-900 dark:text-theme-dark-50';
@@ -45,6 +50,10 @@
             }
         }
     }
+
+    // Show a negative sign if the transaction is a sent payment and the entire
+    // amount is not sent to self.
+    $showMinus = $isSent && !($isSentToSelf && $isAllSentToSelf);
 @endphp
 
 <span {{ $attributes->class($class) }}>
@@ -67,7 +76,7 @@
             data-tippy-content="{{ $fiat }}"
         @endif
     >
-        {{ $isSent && ! $isSentToSelf ? '-' : ($isReceived ? '+' : '')}}
+        {{ $showMinus ? '-' : ($isReceived ? '+' : '')}}
 
         @if (is_numeric($amount))
             {{ ExplorerNumberFormatter::networkCurrency($amount) }}

--- a/tests/Feature/Http/Livewire/Delegates/DelegatesTest.php
+++ b/tests/Feature/Http/Livewire/Delegates/DelegatesTest.php
@@ -118,11 +118,9 @@ it('should filter active delegates', function () {
 
     Livewire::test(Delegates::class)
         ->call('setIsReady')
-        ->set('filter', [
-            'active'   => true,
-            'standby'  => false,
-            'resigned' => false,
-        ])
+        ->set('filter.active', true)
+        ->set('filter.standby', false)
+        ->set('filter.resigned', false)
         ->assertSee($active->address)
         ->assertDontSee($standby->address)
         ->assertDontSee($resigned->address);
@@ -135,11 +133,9 @@ it('should filter standby delegates', function () {
 
     Livewire::test(Delegates::class)
         ->call('setIsReady')
-        ->set('filter', [
-            'active'   => false,
-            'standby'  => true,
-            'resigned' => false,
-        ])
+        ->set('filter.active', false)
+        ->set('filter.standby', true)
+        ->set('filter.resigned', false)
         ->assertSee($standby->address)
         ->assertDontSee($active->address)
         ->assertDontSee($resigned->address);
@@ -152,11 +148,9 @@ it('should filter resigned delegates', function () {
 
     Livewire::test(Delegates::class)
         ->call('setIsReady')
-        ->set('filter', [
-            'active'   => false,
-            'standby'  => false,
-            'resigned' => true,
-        ])
+        ->set('filter.active', false)
+        ->set('filter.standby', false)
+        ->set('filter.resigned', true)
         ->assertSee($resigned->address)
         ->assertDontSee($active->address)
         ->assertDontSee($standby->address);
@@ -165,11 +159,9 @@ it('should filter resigned delegates', function () {
 it('should show correct message when no filters are selected', function () {
     Livewire::test(Delegates::class)
         ->call('setIsReady')
-        ->set('filter', [
-            'active'   => false,
-            'standby'  => false,
-            'resigned' => false,
-        ])
+        ->set('filter.active', false)
+        ->set('filter.standby', false)
+        ->set('filter.resigned', false)
         ->assertSee(trans('tables.delegates.no_results.no_filters'));
 });
 

--- a/tests/Feature/Http/Livewire/Delegates/RecentVotesTest.php
+++ b/tests/Feature/Http/Livewire/Delegates/RecentVotesTest.php
@@ -80,36 +80,28 @@ it('should show no results message if no votes', function () {
 it('should toggle all filters when "select all" is selected', function () {
     Livewire::test(RecentVotes::class)
         ->call('setIsReady')
-        ->assertSet('filter', [
-            'vote'      => true,
-            'unvote'    => true,
-            'vote-swap' => true,
-        ])
+        ->set('filter.vote', true)
+        ->set('filter.unvote', true)
+        ->set('filter.vote-swap', true)
         ->assertSet('selectAllFilters', true)
         ->set('filter.vote', true)
         ->assertSet('selectAllFilters', true)
         ->set('selectAllFilters', false)
-        ->assertSet('filter', [
-            'vote'      => false,
-            'unvote'    => false,
-            'vote-swap' => false,
-        ])
+        ->set('filter.vote', false)
+        ->set('filter.unvote', false)
+        ->set('filter.vote-swap', false)
         ->set('selectAllFilters', true)
-        ->assertSet('filter', [
-            'vote'      => true,
-            'unvote'    => true,
-            'vote-swap' => true,
-        ]);
+        ->set('filter.vote', true)
+        ->set('filter.unvote', true)
+        ->set('filter.vote-swap', true);
 });
 
 it('should toggle "select all" when all filters are selected', function () {
     Livewire::test(RecentVotes::class)
         ->call('setIsReady')
-        ->assertSet('filter', [
-            'vote'      => true,
-            'unvote'    => true,
-            'vote-swap' => true,
-        ])
+        ->set('filter.vote', true)
+        ->set('filter.unvote', true)
+        ->set('filter.vote-swap', true)
         ->assertSet('selectAllFilters', true)
         ->set('filter.vote', false)
         ->assertSet('selectAllFilters', false)
@@ -148,11 +140,9 @@ it('should filter vote transactions', function () {
 
     Livewire::test(RecentVotes::class)
         ->call('setIsReady')
-        ->set('filter', [
-            'vote'      => true,
-            'unvote'    => false,
-            'vote-swap' => false,
-        ])
+        ->set('filter.vote', true)
+        ->set('filter.unvote', false)
+        ->set('filter.vote-swap', false)
         ->assertSee($vote->id)
         ->assertDontSee($unvote->id)
         ->assertDontSee($voteSwap->id);
@@ -189,11 +179,9 @@ it('should filter unvote transactions', function () {
 
     Livewire::test(RecentVotes::class)
         ->call('setIsReady')
-        ->set('filter', [
-            'vote'      => false,
-            'unvote'    => true,
-            'vote-swap' => false,
-        ])
+        ->set('filter.vote', false)
+        ->set('filter.unvote', true)
+        ->set('filter.vote-swap', false)
         ->assertSee($unvote->id)
         ->assertDontSee($vote->id)
         ->assertDontSee($voteSwap->id);
@@ -230,11 +218,9 @@ it('should filter vote swap transactions', function () {
 
     Livewire::test(RecentVotes::class)
         ->call('setIsReady')
-        ->set('filter', [
-            'vote'      => false,
-            'unvote'    => false,
-            'vote-swap' => true,
-        ])
+        ->set('filter.vote', false)
+        ->set('filter.unvote', false)
+        ->set('filter.vote-swap', true)
         ->assertSee($voteSwap->id)
         ->assertDontSee($vote->id)
         ->assertDontSee($unvote->id);
@@ -243,11 +229,9 @@ it('should filter vote swap transactions', function () {
 it('should show correct message when no filters are selected', function () {
     Livewire::test(RecentVotes::class)
         ->call('setIsReady')
-        ->set('filter', [
-            'vote'      => false,
-            'unvote'    => false,
-            'vote-swap' => false,
-        ])
+        ->set('filter.vote', false)
+        ->set('filter.unvote', false)
+        ->set('filter.vote-swap', false)
         ->assertSee(trans('tables.recent-votes.no_results.no_filters'));
 });
 

--- a/tests/Feature/Http/Livewire/TransactionTableTest.php
+++ b/tests/Feature/Http/Livewire/TransactionTableTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use App\Facades\Settings;
 use App\Http\Livewire\TransactionTable;
+use App\Http\Middleware\VerifyCsrfToken;
 use App\Models\Scopes\OrderByTimestampScope;
 use App\Models\Transaction;
 use App\Models\Wallet;
@@ -11,6 +12,8 @@ use App\Services\Cache\CryptoDataCache;
 use App\Services\NumberFormatter;
 use App\ViewModels\ViewModelFactory;
 use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Route;
+use Illuminate\View\Compilers\BladeCompiler;
 use Livewire\Livewire;
 
 it('should list the first page of records', function () {
@@ -287,4 +290,21 @@ it('should reload on new transaction event', function () {
         $component->assertSee('481.00');
         $component->assertSee('0.48');
     }
+});
+
+it('should not reset to page 1 when going back/forward in history', function () {
+    Transaction::factory(100)->create();
+
+    Livewire::withQueryParams(['page' => 2])
+        ->test(TransactionTable::class)
+        ->call('setIsReady')
+        ->update(updates: [
+            'paginators.page' => '3',
+            'perPage' => 25,
+            'filter.transfers' => true,
+            'filter.votes' => true,
+            'filter.multipayments' => true,
+            'filter.others' => true
+        ])
+        ->assertSet('paginators.page', 3);
 });

--- a/tests/Feature/Http/Livewire/TransactionTableTest.php
+++ b/tests/Feature/Http/Livewire/TransactionTableTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 use App\Facades\Settings;
 use App\Http\Livewire\TransactionTable;
-use App\Http\Middleware\VerifyCsrfToken;
 use App\Models\Scopes\OrderByTimestampScope;
 use App\Models\Transaction;
 use App\Models\Wallet;
@@ -12,8 +11,6 @@ use App\Services\Cache\CryptoDataCache;
 use App\Services\NumberFormatter;
 use App\ViewModels\ViewModelFactory;
 use Illuminate\Support\Facades\Config;
-use Illuminate\Support\Facades\Route;
-use Illuminate\View\Compilers\BladeCompiler;
 use Livewire\Livewire;
 
 it('should list the first page of records', function () {
@@ -74,40 +71,32 @@ it('should update the records fiat tooltip when currency changed', function () {
 it('should toggle all filters when "select all" is selected', function () {
     Livewire::test(TransactionTable::class)
         ->call('setIsReady')
-        ->assertSet('filter', [
-            'transfers'     => true,
-            'votes'         => true,
-            'multipayments' => true,
-            'others'        => true,
-        ])
+        ->set('filter.transfers', true)
+        ->set('filter.votes', true)
+        ->set('filter.multipayments', true)
+        ->set('filter.others', true)
         ->assertSet('selectAllFilters', true)
         ->set('filter.transfers', true)
         ->assertSet('selectAllFilters', true)
         ->set('selectAllFilters', false)
-        ->assertSet('filter', [
-            'transfers'     => false,
-            'votes'         => false,
-            'multipayments' => false,
-            'others'        => false,
-        ])
+        ->set('filter.transfers', false)
+        ->set('filter.votes', false)
+        ->set('filter.multipayments', false)
+        ->set('filter.others', false)
         ->set('selectAllFilters', true)
-        ->assertSet('filter', [
-            'transfers'     => true,
-            'votes'         => true,
-            'multipayments' => true,
-            'others'        => true,
-        ]);
+        ->set('filter.transfers', true)
+        ->set('filter.votes', true)
+        ->set('filter.multipayments', true)
+        ->set('filter.others', true);
 });
 
 it('should toggle "select all" when all filters are selected', function () {
     Livewire::test(TransactionTable::class)
         ->call('setIsReady')
-        ->assertSet('filter', [
-            'transfers'     => true,
-            'votes'         => true,
-            'multipayments' => true,
-            'others'        => true,
-        ])
+        ->set('filter.transfers', true)
+        ->set('filter.votes', true)
+        ->set('filter.multipayments', true)
+        ->set('filter.others', true)
         ->assertSet('selectAllFilters', true)
         ->set('filter.transfers', false)
         ->assertSet('selectAllFilters', false)
@@ -128,12 +117,10 @@ it('should filter by transfer transactions', function () {
 
     Livewire::test(TransactionTable::class)
         ->call('setIsReady')
-        ->set('filter', [
-            'transfers'     => true,
-            'votes'         => false,
-            'multipayments' => false,
-            'others'        => false,
-        ])
+        ->set('filter.transfers', true)
+        ->set('filter.votes', false)
+        ->set('filter.multipayments', false)
+        ->set('filter.others', false)
         ->assertSee($transfer->id)
         ->assertDontSee($vote->id);
 });
@@ -151,12 +138,10 @@ it('should filter by vote transactions', function () {
 
     Livewire::test(TransactionTable::class)
         ->call('setIsReady')
-        ->set('filter', [
-            'transfers'     => false,
-            'votes'         => true,
-            'multipayments' => false,
-            'others'        => false,
-        ])
+        ->set('filter.transfers', false)
+        ->set('filter.votes', true)
+        ->set('filter.multipayments', false)
+        ->set('filter.others', false)
         ->assertSee($vote->id)
         ->assertDontSee($transfer->id);
 });
@@ -172,12 +157,10 @@ it('should filter by multipayment transactions', function () {
 
     Livewire::test(TransactionTable::class)
         ->call('setIsReady')
-        ->set('filter', [
-            'transfers'     => false,
-            'votes'         => false,
-            'multipayments' => true,
-            'others'        => false,
-        ])
+        ->set('filter.transfers', false)
+        ->set('filter.votes', false)
+        ->set('filter.multipayments', true)
+        ->set('filter.others', false)
         ->assertSee($multipayment->id)
         ->assertDontSee($transfer->id);
 });
@@ -191,12 +174,10 @@ it('should filter by other transactions', function () {
 
     Livewire::test(TransactionTable::class)
         ->call('setIsReady')
-        ->set('filter', [
-            'transfers'     => false,
-            'votes'         => false,
-            'multipayments' => false,
-            'others'        => true,
-        ])
+        ->set('filter.transfers', false)
+        ->set('filter.votes', false)
+        ->set('filter.multipayments', false)
+        ->set('filter.others', true)
         ->assertSee($delegateRegistration->id)
         ->assertSee($entityRegistration->id)
         ->assertDontSee($transfer->id);
@@ -211,12 +192,10 @@ it('should show no transactions if no type filter', function () {
 
     Livewire::test(TransactionTable::class)
         ->call('setIsReady')
-        ->set('filter', [
-            'transfers'     => false,
-            'votes'         => false,
-            'multipayments' => false,
-            'others'        => false,
-        ])
+        ->set('filter.transfers', false)
+        ->set('filter.votes', false)
+        ->set('filter.multipayments', false)
+        ->set('filter.others', false)
         ->assertDontSee($transfer->id)
         ->assertDontSee($delegateRegistration->id)
         ->assertDontSee($entityRegistration->id)
@@ -226,12 +205,10 @@ it('should show no transactions if no type filter', function () {
 it('should get the filter values via a getter', function () {
     $instance = Livewire::test(TransactionTable::class)
         ->call('setIsReady')
-        ->set('filter', [
-            'transfers'     => false,
-            'votes'         => true,
-            'multipayments' => false,
-            'others'        => true,
-        ])
+        ->set('filter.transfers', false)
+        ->set('filter.votes', true)
+        ->set('filter.multipayments', false)
+        ->set('filter.others', true)
         ->instance();
 
     expect($instance->transfers)->toBeFalse();
@@ -243,12 +220,10 @@ it('should get the filter values via a getter', function () {
 it('should set the filter values via a setter', function () {
     $instance = Livewire::test(TransactionTable::class)
         ->call('setIsReady')
-        ->set('filter', [
-            'transfers'     => false,
-            'votes'         => false,
-            'multipayments' => false,
-            'others'        => false,
-        ])
+        ->set('filter.transfers', false)
+        ->set('filter.votes', false)
+        ->set('filter.multipayments', false)
+        ->set('filter.others', false)
         ->instance();
 
     $instance->transfers     = true;

--- a/tests/Feature/Http/Livewire/WalletTransactionTableTest.php
+++ b/tests/Feature/Http/Livewire/WalletTransactionTableTest.php
@@ -326,14 +326,12 @@ it('should filter by outgoing transactions', function () {
 
     Livewire::test(WalletTransactionTable::class, [new WalletViewModel($this->subject)])
         ->call('setIsReady')
-        ->set('filter', [
-            'outgoing'      => true,
-            'incoming'      => false,
-            'transfers'     => true,
-            'votes'         => false,
-            'multipayments' => false,
-            'others'        => false,
-        ])
+        ->set('filter.outgoing', true)
+        ->set('filter.incoming', false)
+        ->set('filter.transfers', true)
+        ->set('filter.votes', false)
+        ->set('filter.multipayments', false)
+        ->set('filter.others', false)
         ->assertSee($sent->id)
         ->assertDontSee($received->id);
 });
@@ -349,14 +347,12 @@ it('should filter by incoming transactions', function () {
 
     Livewire::test(WalletTransactionTable::class, [new WalletViewModel($this->subject)])
         ->call('setIsReady')
-        ->set('filter', [
-            'outgoing'      => false,
-            'incoming'      => true,
-            'transfers'     => true,
-            'votes'         => false,
-            'multipayments' => false,
-            'others'        => false,
-        ])
+        ->set('filter.outgoing', false)
+        ->set('filter.incoming', true)
+        ->set('filter.transfers', true)
+        ->set('filter.votes', false)
+        ->set('filter.multipayments', false)
+        ->set('filter.others', false)
         ->assertSee($received->id)
         ->assertDontSee($sent->id);
 });
@@ -393,14 +389,12 @@ it('should show multipayments when filtered by incoming transactions', function 
 
     Livewire::test(WalletTransactionTable::class, [new WalletViewModel($this->subject)])
         ->call('setIsReady')
-        ->set('filter', [
-            'outgoing'      => false,
-            'incoming'      => true,
-            'transfers'     => true,
-            'votes'         => false,
-            'multipayments' => true,
-            'others'        => false,
-        ])
+        ->set('filter.outgoing', false)
+        ->set('filter.incoming', true)
+        ->set('filter.transfers', true)
+        ->set('filter.votes', false)
+        ->set('filter.multipayments', true)
+        ->set('filter.others', false)
         ->assertSee($received->id)
         ->assertDontSee($sent->id);
 });
@@ -416,14 +410,12 @@ it('should filter by incoming and outgoing transactions', function () {
 
     Livewire::test(WalletTransactionTable::class, [new WalletViewModel($this->subject)])
         ->call('setIsReady')
-        ->set('filter', [
-            'outgoing'      => true,
-            'incoming'      => true,
-            'transfers'     => true,
-            'votes'         => false,
-            'multipayments' => false,
-            'others'        => false,
-        ])
+        ->set('filter.outgoing', true)
+        ->set('filter.incoming', true)
+        ->set('filter.transfers', true)
+        ->set('filter.votes', false)
+        ->set('filter.multipayments', false)
+        ->set('filter.others', false)
         ->assertSee($sent->id)
         ->assertSee($received->id);
 });
@@ -442,14 +434,12 @@ it('should filter by transfer transactions', function () {
 
     Livewire::test(WalletTransactionTable::class, [new WalletViewModel($this->subject)])
         ->call('setIsReady')
-        ->set('filter', [
-            'outgoing'      => true,
-            'incoming'      => false,
-            'transfers'     => true,
-            'votes'         => false,
-            'multipayments' => false,
-            'others'        => false,
-        ])
+        ->set('filter.outgoing', true)
+        ->set('filter.incoming', false)
+        ->set('filter.transfers', true)
+        ->set('filter.votes', false)
+        ->set('filter.multipayments', false)
+        ->set('filter.others', false)
         ->assertSee($transfer->id)
         ->assertDontSee($vote->id);
 });
@@ -468,14 +458,12 @@ it('should filter by vote transactions', function () {
 
     Livewire::test(WalletTransactionTable::class, [new WalletViewModel($this->subject)])
         ->call('setIsReady')
-        ->set('filter', [
-            'outgoing'      => true,
-            'incoming'      => false,
-            'transfers'     => false,
-            'votes'         => true,
-            'multipayments' => false,
-            'others'        => false,
-        ])
+        ->set('filter.outgoing', true)
+        ->set('filter.incoming', false)
+        ->set('filter.transfers', false)
+        ->set('filter.votes', true)
+        ->set('filter.multipayments', false)
+        ->set('filter.others', false)
         ->assertSee($vote->id)
         ->assertDontSee($transfer->id);
 });
@@ -491,14 +479,12 @@ it('should filter by multipayment transactions', function () {
 
     Livewire::test(WalletTransactionTable::class, [new WalletViewModel($this->subject)])
         ->call('setIsReady')
-        ->set('filter', [
-            'outgoing'      => true,
-            'incoming'      => false,
-            'transfers'     => false,
-            'votes'         => false,
-            'multipayments' => true,
-            'others'        => false,
-        ])
+        ->set('filter.outgoing', true)
+        ->set('filter.incoming', false)
+        ->set('filter.transfers', false)
+        ->set('filter.votes', false)
+        ->set('filter.multipayments', true)
+        ->set('filter.others', false)
         ->assertSee($multipayment->id)
         ->assertDontSee($transfer->id);
 });
@@ -518,14 +504,12 @@ it('should filter by other transactions', function () {
 
     Livewire::test(WalletTransactionTable::class, [new WalletViewModel($this->subject)])
         ->call('setIsReady')
-        ->set('filter', [
-            'outgoing'      => true,
-            'incoming'      => false,
-            'transfers'     => false,
-            'votes'         => false,
-            'multipayments' => false,
-            'others'        => true,
-        ])
+        ->set('filter.outgoing', true)
+        ->set('filter.incoming', false)
+        ->set('filter.transfers', false)
+        ->set('filter.votes', false)
+        ->set('filter.multipayments', false)
+        ->set('filter.others', true)
         ->assertSee($delegateRegistration->id)
         ->assertSee($entityRegistration->id)
         ->assertDontSee($transfer->id);
@@ -546,14 +530,12 @@ it('should show no transactions if no filters', function () {
 
     Livewire::test(WalletTransactionTable::class, [new WalletViewModel($this->subject)])
         ->call('setIsReady')
-        ->set('filter', [
-            'outgoing'      => false,
-            'incoming'      => false,
-            'transfers'     => false,
-            'votes'         => false,
-            'multipayments' => false,
-            'others'        => false,
-        ])
+        ->set('filter.outgoing', false)
+        ->set('filter.incoming', false)
+        ->set('filter.transfers', false)
+        ->set('filter.votes', false)
+        ->set('filter.multipayments', false)
+        ->set('filter.others', false)
         ->assertDontSee($transfer->id)
         ->assertDontSee($delegateRegistration->id)
         ->assertDontSee($entityRegistration->id)
@@ -575,14 +557,12 @@ it('should show no transactions if no addressing filter', function () {
 
     Livewire::test(WalletTransactionTable::class, [new WalletViewModel($this->subject)])
         ->call('setIsReady')
-        ->set('filter', [
-            'outgoing'      => false,
-            'incoming'      => false,
-            'transfers'     => true,
-            'votes'         => true,
-            'multipayments' => true,
-            'others'        => true,
-        ])
+        ->set('filter.outgoing', false)
+        ->set('filter.incoming', false)
+        ->set('filter.transfers', true)
+        ->set('filter.votes', true)
+        ->set('filter.multipayments', true)
+        ->set('filter.others', true)
         ->assertDontSee($transfer->id)
         ->assertDontSee($delegateRegistration->id)
         ->assertDontSee($entityRegistration->id)
@@ -604,14 +584,12 @@ it('should show no transactions if no type filter', function () {
 
     Livewire::test(WalletTransactionTable::class, [new WalletViewModel($this->subject)])
         ->call('setIsReady')
-        ->set('filter', [
-            'outgoing'      => true,
-            'incoming'      => true,
-            'transfers'     => false,
-            'votes'         => false,
-            'multipayments' => false,
-            'others'        => false,
-        ])
+        ->set('filter.outgoing', true)
+        ->set('filter.incoming', true)
+        ->set('filter.transfers', false)
+        ->set('filter.votes', false)
+        ->set('filter.multipayments', false)
+        ->set('filter.others', false)
         ->assertDontSee($transfer->id)
         ->assertDontSee($delegateRegistration->id)
         ->assertDontSee($entityRegistration->id)


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/86dvpr1py

Somewhere along the way, I believe in the move to v3 of Livewire, something happened whereby the `updated` hook gets triggered on history change (going forward/backwards in the browser). In this case, the change resulted in the `$filter` property always triggering the `update` hooks, even though the value doesn't change. The fix in this case is to do a specific check to see if anything changes and to reset the page if it has. I needed to switch to the `updating` hook in order to do this prior to the value being changed in the component as it's already changed at that point.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my UI changes in light AND dark mode
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
