### PR TITLE
refactor: validator public key remove unused code

### DIFF
--- a/app/ViewModels/Concerns/Transaction/CanBeValidatorRegistration.php
+++ b/app/ViewModels/Concerns/Transaction/CanBeValidatorRegistration.php
@@ -12,7 +12,10 @@ trait CanBeValidatorRegistration
             return null;
         }
 
-        [2 => $arguments] = $this->getMethodData();
+        /** @var array $methodData */
+        $methodData = $this->getMethodData();
+
+        [2 => $arguments] = $methodData;
 
         return $arguments[0];
     }

--- a/app/ViewModels/Concerns/Transaction/CanBeValidatorRegistration.php
+++ b/app/ViewModels/Concerns/Transaction/CanBeValidatorRegistration.php
@@ -12,16 +12,7 @@ trait CanBeValidatorRegistration
             return null;
         }
 
-        $methodData = $this->getMethodData();
-        // @codeCoverageIgnoreStart
-        // Not covered in tests, since having a null value depends on returning
-        // null on the rawPayload method which I was not able to mock
-        if ($methodData === null) {
-            return null;
-        }
-        // @codeCoverageIgnoreEnd
-
-        [2 => $arguments] = $methodData;
+        [2 => $arguments] = $this->getMethodData();
 
         return $arguments[0];
     }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/86dvfy8p0

This code is unreachable. If `rawPayload` is null, it will exit at the `isValidatorRegistration` call. The only way for `getMethodData` to return null is if `rawPayload` does.

Edit: my theory is that I added the null check to satisfy phpstan

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my UI changes in light AND dark mode
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
