### PR TITLE
chore: remove extra parameter on address component

### DIFF
--- a/resources/views/components/tables/rows/desktop/encapsulated/address.blade.php
+++ b/resources/views/components/tables/rows/desktop/encapsulated/address.blade.php
@@ -33,7 +33,6 @@
         <span>
             <x-general.identity
                 :model="$model"
-                :address="$address"
                 :without-truncate="$withoutTruncate"
                 :validator-name-class="$validatorNameClass"
             >


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/86dvnzz5u

Removes an extra line added here https://github.com/ArdentHQ/arkscan/pull/1142/files#diff-f945b1db2b2ea716748bced8e4fc92294d4c31dac0c6360f5c7c66da918f9668R36. Does not cause any issue because the slot overrides the value but still is an error.

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my UI changes in light AND dark mode
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
