### PR TITLE
refactor: truncate validator stats addresses

### DIFF
--- a/resources/views/components/stats/insights/desktop/validator-row.blade.php
+++ b/resources/views/components/stats/insights/desktop/validator-row.blade.php
@@ -20,7 +20,7 @@
                     href="{{ route('wallet', $model->model()) }}"
                     class="link"
                 >
-                    {{ $model->address() }}
+                    <x-truncate-middle>{{ $model->address() }}</x-truncate-middle>
                 </a>
             @endif
         </div>

--- a/resources/views/components/stats/insights/mobile/validator-row.blade.php
+++ b/resources/views/components/stats/insights/mobile/validator-row.blade.php
@@ -19,7 +19,7 @@
                         href="{{ route('wallet', $model->model()) }}"
                         class="link"
                     >
-                        {{ $model->address() }}
+                        <x-truncate-middle>{{ $model->address() }}</x-truncate-middle>
                     </a>
                 @endif
             </span>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

We have enough space to truncate with more characters, but it doesn’t seem like we’ve changed the default truncation length for addresses in the rest of the app, so I’m keeping the default one. Open to discussion.

https://app.clickup.com/t/86dvpfp0v

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my UI changes in light AND dark mode
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
