### PR TITLE
fix: double button on mobile

### DIFF
--- a/resources/views/components/arkconnect/modal/unsupported-browser.blade.php
+++ b/resources/views/components/arkconnect/modal/unsupported-browser.blade.php
@@ -1,5 +1,5 @@
 <div
-    x-show="! isSupported"
+    x-show="! isSupported && !hasExtension"
     x-data="Modal.alpine({ shown: false })"
     x-cloak
 >

--- a/resources/views/components/navbar/arkconnect.blade.php
+++ b/resources/views/components/navbar/arkconnect.blade.php
@@ -7,7 +7,7 @@
     <div x-show="hasExtension && isSupported">
         <button
             x-show="! isConnected"
-            class="py-1.5 px-4 whitespace-nowrap button-secondary w-full"
+            class="py-1.5 px-4 w-full whitespace-nowrap button-secondary"
             @click="connect"
             :disabled="! hasExtension"
             disabled

--- a/resources/views/components/navbar/arkconnect.blade.php
+++ b/resources/views/components/navbar/arkconnect.blade.php
@@ -7,7 +7,7 @@
     <div x-show="hasExtension && isSupported">
         <button
             x-show="! isConnected"
-            class="py-1.5 px-4 whitespace-nowrap button-secondary"
+            class="py-1.5 px-4 whitespace-nowrap button-secondary w-full"
             @click="connect"
             :disabled="! hasExtension"
             disabled


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Errors occur when using the browser devtools and opening the page in mobile view with the extension previously installed. Since it is detected as mobile, the browser is considered unsupported so it shows the button the shows the "unsupported modal". However, since the the extension is already installed it also shows the button for that scenario.

An extra condition was added to hide the "unsupported" button if the extension is already installed.

Note: also adjusted the width of the button

https://app.clickup.com/t/86dvpz0gu

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my UI changes in light AND dark mode
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
