### PR TITLE
refactor: prevent decimals on supply

### DIFF
--- a/resources/views/livewire/home/statistics.blade.php
+++ b/resources/views/livewire/home/statistics.blade.php
@@ -13,7 +13,7 @@
             </x-home.stat>
 
             <x-home.stat :title="trans('pages.home.statistics.current_supply')" class="pt-3">
-                <x-currency :currency="Network::currency()">{{ $supply }}</x-currency>
+                <x-currency :currency="Network::currency()">{{ round($supply) }}</x-currency>
             </x-home.stat>
         </div>
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Currently it's not showing any decimals since the returned supply is a round number, but adding a `round` method to prevent issues in case that changes.

https://app.clickup.com/t/86dwc6gh0

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my UI changes in light AND dark mode
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
