### PR TITLE
refactor: annual statistics calculate multipayment

### DIFF
--- a/app/Console/Commands/CacheAnnualStatistics.php
+++ b/app/Console/Commands/CacheAnnualStatistics.php
@@ -15,7 +15,6 @@ use ArkEcosystem\Crypto\Utils\UnitConverter;
 use Carbon\Carbon;
 use Illuminate\Console\Command;
 use Illuminate\Support\Arr;
-use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 
 final class CacheAnnualStatistics extends Command
@@ -99,7 +98,7 @@ final class CacheAnnualStatistics extends Command
                 (string) BigNumber::new(UnitConverter::formatUnits($itemData['fees'], 'ark')),
                 $blocksData->get($key)?->blocks, // We assume to have the same value of entries for blocks and transactions (years)
             );
-        };
+        }
     }
 
     private function cacheCurrentYear(StatisticsCache $cache): void

--- a/app/Services/Transactions/Aggregates/Historical/AveragesAggregate.php
+++ b/app/Services/Transactions/Aggregates/Historical/AveragesAggregate.php
@@ -16,11 +16,12 @@ final class AveragesAggregate
 {
     public function aggregate(): array
     {
-        /** @var object{count: int, fee: string, value: BigNumber} */
+        /** @var object{count: int, fee: string, value: BigNumber, recipient_value: BigNumber} */
         $data = Transaction::select([
                 DB::raw('COUNT(*) as count'),
                 DB::raw('SUM(transactions.gas_price * COALESCE(receipts.gas_used, 0)) as fee'),
-                DB::raw('SUM(transactions.value) + COALESCE(SUM(recipient_amount), 0) as value'),
+                DB::raw('SUM(transactions.value) FILTER (WHERE COALESCE(is_multipayment, FALSE) != TRUE) as value'),
+                DB::raw('COALESCE(SUM(recipient_amount), 0) as recipient_value'),
             ])
             ->join('receipts', 'transactions.hash', '=', 'receipts.transaction_hash')
             ->withScope(MultiPaymentTotalAmountScope::class)
@@ -36,9 +37,11 @@ final class AveragesAggregate
             ];
         }
 
+        $totalAmount = $data->value->plus($data->recipient_value)->toFloat();
+
         return [
             'count'  => (int) round($data->count / $daysSinceEpoch),
-            'amount' => (int) round(($data->value->toFloat()) / $daysSinceEpoch),
+            'amount' => (int) round($totalAmount / $daysSinceEpoch),
             'fee'    => UnitConverter::formatUnits(
                 (string) BigNumber::new($data->fee)->valueOf()->dividedBy($daysSinceEpoch, null, RoundingMode::DOWN),
                 'wei'

--- a/app/Services/Transactions/Aggregates/Historical/AveragesAggregate.php
+++ b/app/Services/Transactions/Aggregates/Historical/AveragesAggregate.php
@@ -37,7 +37,7 @@ final class AveragesAggregate
             ];
         }
 
-        $totalAmount = $data->value->plus($data->recipient_value)->toFloat();
+        $totalAmount = $data->value->plus((string) $data->recipient_value)->toFloat();
 
         return [
             'count'  => (int) round($data->count / $daysSinceEpoch),

--- a/database/factories/TransactionFactory.php
+++ b/database/factories/TransactionFactory.php
@@ -85,7 +85,12 @@ final class TransactionFactory extends Factory
 
         foreach ($recipients as $index => $recipient) {
             $pay[0][] = $recipient;
-            $pay[1][] = $amounts[$index]->__toString();
+            $pay[1][] = (string) $amounts[$index];
+        }
+
+        $totalAmount = BigNumber::zero();
+        foreach ($amounts as $amount) {
+            $totalAmount = $totalAmount->plus((string) $amount);
         }
 
         $payload = (new AbiEncoder(ContractAbiType::MULTIPAYMENT))
@@ -95,7 +100,7 @@ final class TransactionFactory extends Factory
 
         return $this->withPayload($payload)
             ->state(fn () => [
-                'value'            => 0,
+                'value'            => (string) $totalAmount,
                 'to'               => Network::knownContract('multipayment'),
             ]);
     }

--- a/tests/Unit/Console/Commands/CacheAnnualStatisticsTest.php
+++ b/tests/Unit/Console/Commands/CacheAnnualStatisticsTest.php
@@ -104,9 +104,6 @@ it('should cache annual data for all time', function () {
         ->count(3)
         ->withReceipt()
         ->create([
-            // @TODO: Amount is the sum of all the individual payments but may not
-            // represent a real world scenario and should not be considered accurate
-            // @see https://app.clickup.com/t/86dvf5xcm
             'value' => BigNumber::new(10 * 1e18)->plus(1 * 1e18),
         ]);
 
@@ -530,12 +527,23 @@ it('should get all annual data if not already set', function () {
     expect($cache->getAnnualData(2017))->toBeNull();
 
     // 2017
-    Transaction::factory()
-        ->count(6)
+    Transaction::factory(6)
         ->withReceipt()
         ->create([
             'timestamp' => Carbon::parse('2017-03-21 13:00:00')->getTimestampMs(),
             'value'     => 10 * 1e18,
+            'gas_price' => 100000000,
+        ]);
+
+    Transaction::factory(3)
+        ->multiPayment([
+            Wallet::factory()->create()->address,
+            Wallet::factory()->create()->address,
+        ], [BigNumber::new(10 * 1e18), BigNumber::new(1 * 1e18)])
+        ->withReceipt()
+        ->create([
+            'timestamp' => Carbon::parse('2017-03-21 13:00:00')->getTimestampMs(),
+            'value'     => 11 * 1e18,
             'gas_price' => 100000000,
         ]);
 
@@ -547,9 +555,9 @@ it('should get all annual data if not already set', function () {
 
     expect($cache->getAnnualData(2017))->toBe([
         'year'         => 2017,
-        'transactions' => 6,
-        'volume'       => '60.0000000000000000',
-        'fees'         => '0.0000126',
+        'transactions' => 9,
+        'volume'       => '93.0000000000000000',
+        'fees'         => '0.0000189',
         'blocks'       => 6,
     ]);
 });
@@ -593,9 +601,6 @@ it('should not cache all annual data if already set', function () {
         ->count(3)
         ->withReceipt()
         ->create([
-            // @TODO: Amount is the sum of all the individual payments but may not
-            // represent a real world scenario and should not be considered accurate
-            //  @see https://app.clickup.com/t/86dvf5xcm
             'value' => BigNumber::new(10 * 1e18)->plus(1 * 1e18),
         ]);
 
@@ -656,9 +661,6 @@ it('should cache all annual data with flag even if not already set', function ()
         ->count(3)
         ->withReceipt()
         ->create([
-            // @TODO: Amount is the sum of all the individual payments but may not
-            // represent a real world scenario and should not be considered accurate
-            // @see https://app.clickup.com/t/86dvf5xcm
             'value' => BigNumber::new(10 * 1e18)->plus(1 * 1e18),
         ]);
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/86dvxzg6t

Added the MultipaymentTotalAmountScope to the CacheAnnualStatistics calculation. While doing this, I realised that it was also taking the `value` for multipayments and including that in the total, as well as the recipient amounts (did the same in the AveragesAggregate). So this fixes AveragesAggregate and adds multipay amounts to annual statistics

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my UI changes in light AND dark mode
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
