### PR TITLE
fix: transaction amount component handling

### DIFF
--- a/resources/views/components/transaction/page/summary.blade.php
+++ b/resources/views/components/transaction/page/summary.blade.php
@@ -30,7 +30,11 @@
             <div class="flex justify-end items-center space-x-2 sm:justify-start">
                 @php ($registration = $transaction->validatorRegistration())
 
-                <x-transaction.amount :transaction="$registration ?? $transaction" />
+                @if ($registration && $registration->amount() > 0)
+                    <x-transaction.amount :amount="$registration->amount()" />
+                @else
+                    <x-transaction.amount :amount="$transaction->amount()" />
+                @endif
 
                 <x-tables.headers.desktop.includes.tooltip
                     :text="$registration && $registration->amount() > 0 ? trans('pages.transaction.unlocked_amount_tooltip') : trans('pages.transaction.legacy_registration_tooltip')"


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

noticed while working on https://app.clickup.com/t/86dx2ga24

there's a scenario where validator resignations were incorrectly using the transaction model as a the amount argument which would never work. this changes it so that the amount is passed in directly. related to https://github.com/ArdentHQ/arkscan/pull/1216

resolves [app.clickup.com/t/86dx2qpq4](https://app.clickup.com/t/86dx2qpq4)

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my UI changes in light AND dark mode
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
