### PR TITLE
refactor: handle other abi methods

### DIFF
--- a/app/Services/Transactions/TransactionMethod.php
+++ b/app/Services/Transactions/TransactionMethod.php
@@ -6,10 +6,13 @@ namespace App\Services\Transactions;
 
 use App\Enums\ContractMethod;
 use App\Models\Transaction;
+use Illuminate\Support\Str;
 
 final class TransactionMethod
 {
-    private ?string $methodHash;
+    private ?string $methodHash = null;
+
+    private ?string $methodName = null;
 
     private array $types = [
         'isTransfer'              => 'transfer',
@@ -26,7 +29,15 @@ final class TransactionMethod
 
     public function __construct(private Transaction $transaction)
     {
-        $this->methodHash = $transaction->methodHash();
+        $methodData = $this->transaction->getMethodData(true);
+        if ($methodData === null) {
+            $this->methodHash = $transaction->methodHash();
+        } else {
+            [$methodName, $methodHash] = $methodData;
+
+            $this->methodHash = $methodHash;
+            $this->methodName = $methodName;
+        }
     }
 
     public function name(): string
@@ -44,6 +55,10 @@ final class TransactionMethod
             if ($methodName !== null) {
                 return $methodName;
             }
+        }
+
+        if ($this->methodName !== null) {
+            return str_replace('_', ' ', Str::title(Str::snake($this->methodName)));
         }
 
         return '0x'.$this->methodHash;

--- a/tests/Unit/Services/Transactions/TransactionMethodTest.php
+++ b/tests/Unit/Services/Transactions/TransactionMethodTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Facades\Network;
 use App\Models\Transaction;
 use App\Models\Wallet;
 use App\Services\Transactions\TransactionMethod;
@@ -72,4 +73,19 @@ it('should return raw methodHash if no type matches and translation is missing',
     $transactionMethod = new TransactionMethod($transaction);
 
     expect($transactionMethod->name())->toBe('0x'.$unknownMethodHash);
+});
+
+it('should return the ABI name if not handled', function () {
+    $wallet = Wallet::factory()->create();
+    $method = 'e5abdcef'.str_pad(bin2hex('username'), 64, '0', STR_PAD_LEFT);
+
+    $transaction = Transaction::factory()
+        ->withPayload($method)
+        ->create([
+            'to' => Network::knownContract('username'),
+        ]);
+
+    $transactionMethod = new TransactionMethod($transaction);
+
+    expect($transactionMethod->name())->toBe('Add Username');
 });


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/86dx58yum

Determines a Transaction "type" name in the following order:

- checks each type we've explicitly defined (e.g. isMultipayment) and uses a name we've specified in langs
- checks to see if the payload hash is used in the langs file `contracts` and uses that if so
- adjusts the function name from the abi to be readable (assuming the function was found in the ABI)
- falls back to `0x<PAYLOAD_HASH>`

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my UI changes in light AND dark mode
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
