### PR TITLE
chore: remove largest transaction todo

### DIFF
--- a/app/Services/Transactions/Aggregates/LargestTransactionAggregate.php
+++ b/app/Services/Transactions/Aggregates/LargestTransactionAggregate.php
@@ -10,6 +10,8 @@ final class LargestTransactionAggregate
 {
     public function aggregate(): ?Transaction
     {
-        return Transaction::orderBy('value', 'desc')->limit(1)->first();
+        return Transaction::orderBy('value', 'desc')
+            ->limit(1)
+            ->first();
     }
 }

--- a/app/Services/Transactions/Aggregates/LargestTransactionAggregate.php
+++ b/app/Services/Transactions/Aggregates/LargestTransactionAggregate.php
@@ -10,7 +10,6 @@ final class LargestTransactionAggregate
 {
     public function aggregate(): ?Transaction
     {
-        // TODO: add transaction type for transfer - https://app.clickup.com/t/86dvxzh7f
         return Transaction::orderBy('value', 'desc')->limit(1)->first();
     }
 }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/86dvxzh7f

I think it's redundant to add specific scopes for the LargestTransactionAggregate so this just removed the TODO

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my UI changes in light AND dark mode
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
