### PR TITLE
refactor: remove redundant alpine properties in inertia component 

### DIFF
--- a/resources/inertia/Components/Tabs/Wrapper.tsx
+++ b/resources/inertia/Components/Tabs/Wrapper.tsx
@@ -25,18 +25,7 @@ export default function Wrapper({ tabs }: { tabs: ITab[] }) {
     }, []);
 
     return (
-        <div
-            x-data="{
-                showOverflowIndicators: false,
-                checkOverflow: function () {
-                    const container = this.$refs.container;
-
-                    this.showOverflowIndicators = container.scrollWidth > container.clientWidth;
-                },
-            }"
-            className="relative px-0 sm:mb-3 sm:px-6 md:mx-auto md:max-w-7xl md:px-10"
-            x-resize="checkOverflow()"
-        >
+        <div className="relative px-0 sm:mb-3 sm:px-6 md:mx-auto md:max-w-7xl md:px-10">
             {showOverflowIndicators && (
                 <>
                     <div className="to-theme-secondary-200/0 dark:to-theme-dark-950/0 pointer-events-none absolute left-0 top-0 z-20 h-12 h-full w-12 bg-gradient-to-r from-theme-secondary-200 dark:from-theme-dark-950"></div>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Related to https://app.clickup.com/t/86dyneuwj

As part of #1344, some AlpineJS was accidentally copied across to an Inertia component. This was throwing errors in devtools

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my UI changes in light AND dark mode
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
